### PR TITLE
タブ紐付け不具合と編集状態検知の修正

### DIFF
--- a/background.js
+++ b/background.js
@@ -11,19 +11,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 async function handleIssueUpdated(data, tabId) {
-  const issues = await db.getAllIssues();
-
-  // 同じタブで以前開いていた他の課題のステータスを更新
-  for (const issue of issues) {
-    if (issue.tabId === tabId && issue.url !== data.url) {
-      await db.upsertIssue({
-        url: issue.url,
-        isOpened: false,
-        isEditing: false,
-        tabId: null
-      });
-    }
-  }
+  // 同じタブで以前開いていた他の課題のステータスを効率的に更新
+  await db.clearTabAssociation(tabId, data.url);
 
   const issueData = {
     ...data,
@@ -35,20 +24,8 @@ async function handleIssueUpdated(data, tabId) {
 }
 
 chrome.tabs.onRemoved.addListener(async (tabId) => {
-  const issues = await db.getAllIssues();
-  const issuesToUpdate = issues.filter(i => i.tabId === tabId);
-
-  if (issuesToUpdate.length > 0) {
-    for (const issue of issuesToUpdate) {
-      await db.upsertIssue({
-        url: issue.url,
-        isOpened: false,
-        isEditing: false,
-        tabId: null
-      });
-    }
-    chrome.runtime.sendMessage({ type: 'DB_UPDATED' }).catch(() => {});
-  }
+  await db.clearTabAssociation(tabId);
+  chrome.runtime.sendMessage({ type: 'DB_UPDATED' }).catch(() => {});
 });
 
 chrome.runtime.onInstalled.addListener(async () => {

--- a/background.js
+++ b/background.js
@@ -6,27 +6,47 @@ chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'ISSUE_UPDATED') {
-    const issueData = {
-      ...message.data,
-      tabId: sender.tab.id,
-      isOpened: true
-    };
-    db.upsertIssue(issueData).then(() => {
-      chrome.runtime.sendMessage({ type: 'DB_UPDATED' }).catch(() => {});
-    });
+    handleIssueUpdated(message.data, sender.tab.id);
   }
 });
 
+async function handleIssueUpdated(data, tabId) {
+  const issues = await db.getAllIssues();
+
+  // 同じタブで以前開いていた他の課題のステータスを更新
+  for (const issue of issues) {
+    if (issue.tabId === tabId && issue.url !== data.url) {
+      await db.upsertIssue({
+        url: issue.url,
+        isOpened: false,
+        isEditing: false,
+        tabId: null
+      });
+    }
+  }
+
+  const issueData = {
+    ...data,
+    tabId: tabId,
+    isOpened: true
+  };
+  await db.upsertIssue(issueData);
+  chrome.runtime.sendMessage({ type: 'DB_UPDATED' }).catch(() => {});
+}
+
 chrome.tabs.onRemoved.addListener(async (tabId) => {
   const issues = await db.getAllIssues();
-  const issueToUpdate = issues.find(i => i.tabId === tabId);
-  if (issueToUpdate) {
-    await db.upsertIssue({
-      url: issueToUpdate.url, // URL をキーに使用
-      isOpened: false,
-      isEditing: false,
-      tabId: null
-    });
+  const issuesToUpdate = issues.filter(i => i.tabId === tabId);
+
+  if (issuesToUpdate.length > 0) {
+    for (const issue of issuesToUpdate) {
+      await db.upsertIssue({
+        url: issue.url,
+        isOpened: false,
+        isEditing: false,
+        tabId: null
+      });
+    }
     chrome.runtime.sendMessage({ type: 'DB_UPDATED' }).catch(() => {});
   }
 });

--- a/content.js
+++ b/content.js
@@ -18,11 +18,6 @@
     const issueKey = getIssueKey();
     if (!issueKey) return;
 
-    // 状態が変わった時だけ送信して負荷を軽減
-    if (isEditing === isEditingState && !isEditing) {
-       // 初期ロード時などは常に送信したいので、初回は通す
-    }
-
     chrome.runtime.sendMessage({
       type: 'ISSUE_UPDATED',
       data: {
@@ -48,30 +43,62 @@
     }
   }).observe(document, { subtree: true, childList: true });
 
-  // デバウンス用のタイマー
-  let inputTimeout;
+  const isEditableElement = (el) => {
+    if (!el) return false;
+    const tagName = el.tagName;
+    const role = el.getAttribute('role');
+    const isContentEditable = el.isContentEditable;
 
-  const handleInput = (e) => {
-    const target = e.target;
-    if (target.tagName === 'TEXTAREA' ||
-        target.tagName === 'INPUT' ||
-        target.isContentEditable ||
-        target.getAttribute('role') === 'textbox') {
+    return (
+      tagName === 'TEXTAREA' ||
+      (tagName === 'INPUT' && !['button', 'submit', 'checkbox', 'radio', 'hidden'].includes(el.type)) ||
+      isContentEditable ||
+      role === 'textbox' ||
+      role === 'combobox'
+    );
+  };
 
-      if (!isEditingState) {
-        notifyChange(true);
-      }
+  const checkEditingState = () => {
+    const activeElement = document.activeElement;
+    const isEditing = isEditableElement(activeElement);
 
-      // 一定時間入力がなければ編集終了とみなす（簡易的な判定）
-      clearTimeout(inputTimeout);
-      inputTimeout = setTimeout(() => {
-        // 実際にはフォーカスが外れるまで維持したほうが安全かもしれないが
-        // PRコメントの「妥当性」を考慮し、過剰な通知を抑制する。
-      }, 5000);
+    if (isEditing !== isEditingState) {
+      notifyChange(isEditing);
     }
   };
 
-  document.addEventListener('focusin', handleInput);
-  document.addEventListener('input', handleInput);
+  // 編集状態の監視
+  document.addEventListener('focusin', checkEditingState);
+  document.addEventListener('focusout', () => {
+    // フォーカスが外れた直後は次の要素にフォーカスが移る前なので、少し待ってから確認
+    setTimeout(checkEditingState, 200);
+  });
+
+  // キー操作による編集終了（EnterやEscape）の検知
+  document.addEventListener('keydown', (e) => {
+    if (isEditingState) {
+      if (e.key === 'Escape') {
+        // Escapeはキャンセル扱いで編集終了とみなす
+        setTimeout(checkEditingState, 200);
+      } else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+        // Ctrl+Enter / Cmd+Enter は保存扱いで編集終了とみなす
+        setTimeout(checkEditingState, 200);
+      }
+    }
+  }, true);
+
+  // 保存・キャンセルボタンのクリックを検知
+  document.addEventListener('click', (e) => {
+    const target = e.target;
+    // Jiraの保存・キャンセルボタンは button か span/div で構成されていることが多い
+    const isButton = target.closest('button') ||
+                     target.tagName === 'BUTTON' ||
+                     (target.getAttribute('role') === 'button');
+
+    if (isButton) {
+      // ボタンクリック時は編集状態が変わる可能性が高い
+      setTimeout(checkEditingState, 500);
+    }
+  }, true);
 
 })();

--- a/db.js
+++ b/db.js
@@ -1,24 +1,35 @@
 export class IssuesDB {
   constructor() {
     this.dbName = 'IssuesSoloDB';
-    this.dbVersion = 2; // バージョンアップ
+    this.dbVersion = 3; // バージョンアップ: tabId インデックスの追加
     this.storeName = 'issues';
+    this._db = null;
   }
 
   async open() {
+    if (this._db) return this._db;
+
     return new Promise((resolve, reject) => {
       const request = indexedDB.open(this.dbName, this.dbVersion);
 
       request.onupgradeneeded = (event) => {
         const db = event.target.result;
-        // バージョン 2 では keyPath を url に変更
-        if (db.objectStoreNames.contains(this.storeName)) {
-          db.deleteObjectStore(this.storeName);
+        let store;
+        if (!db.objectStoreNames.contains(this.storeName)) {
+          store = db.createObjectStore(this.storeName, { keyPath: 'url' });
+        } else {
+          store = event.currentTarget.transaction.objectStore(this.storeName);
         }
-        db.createObjectStore(this.storeName, { keyPath: 'url' });
+
+        if (!store.indexNames.contains('tabId')) {
+          store.createIndex('tabId', 'tabId', { unique: false });
+        }
       };
 
-      request.onsuccess = () => resolve(request.result);
+      request.onsuccess = () => {
+        this._db = request.result;
+        resolve(this._db);
+      };
       request.onerror = () => reject(request.error);
     });
   }
@@ -38,6 +49,33 @@ export class IssuesDB {
         putRequest.onerror = () => reject(putRequest.error);
       };
       getRequest.onerror = () => reject(getRequest.error);
+    });
+  }
+
+  async clearTabAssociation(tabId, exceptUrl = null) {
+    const db = await this.open();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([this.storeName], 'readwrite');
+      const store = transaction.objectStore(this.storeName);
+      const index = store.index('tabId');
+      const request = index.openCursor(IDBKeyRange.only(tabId));
+
+      request.onsuccess = (event) => {
+        const cursor = event.target.result;
+        if (cursor) {
+          const issue = cursor.value;
+          if (issue.url !== exceptUrl) {
+            issue.isOpened = false;
+            issue.isEditing = false;
+            issue.tabId = null;
+            cursor.update(issue);
+          }
+          cursor.continue();
+        } else {
+          resolve();
+        }
+      };
+      request.onerror = () => reject(request.error);
     });
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Issues-Solo",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "permissions": [
     "sidePanel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "mkdir -p releases && zip -r releases/issues-solo-v$npm_package_version.zip manifest.json background.js content.js db.js sidepanel.html sidepanel.js sidepanel.css LICENSE"

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -11,7 +11,7 @@ async function renderList() {
     return;
   }
 
-  listElement.innerHTML = '';
+  listElement.textContent = '';
   issues.forEach(issue => {
     const item = document.createElement('div');
     item.className = 'issue-item';
@@ -19,16 +19,43 @@ async function renderList() {
     // インスタンスを区別するためにドメインを表示
     const domain = new URL(issue.url).hostname;
 
-    item.innerHTML = `
-      <div class="status-indicators">
-        <div class="indicator ${issue.isOpened ? 'is-opened' : ''}" title="${issue.isOpened ? 'Tab is open' : 'Tab is closed'}"></div>
-        <div class="indicator ${issue.isEditing ? 'is-editing' : ''}" title="${issue.isEditing ? 'Currently editing' : ''}"></div>
-      </div>
-      <div class="issue-content">
-        <span class="issue-key">${issue.issueKey} <small style="color: #6b778c; font-weight: normal;">(${domain})</small></span>
-        <span class="issue-title">${escapeHtml(issue.title)}</span>
-      </div>
-    `;
+    const indicators = document.createElement('div');
+    indicators.className = 'status-indicators';
+
+    const openIndicator = document.createElement('div');
+    openIndicator.className = `indicator ${issue.isOpened ? 'is-opened' : ''}`;
+    openIndicator.title = issue.isOpened ? 'Tab is open' : 'Tab is closed';
+
+    const editIndicator = document.createElement('div');
+    editIndicator.className = `indicator ${issue.isEditing ? 'is-editing' : ''}`;
+    editIndicator.title = issue.isEditing ? 'Currently editing' : '';
+
+    indicators.appendChild(openIndicator);
+    indicators.appendChild(editIndicator);
+
+    const content = document.createElement('div');
+    content.className = 'issue-content';
+
+    const keySpan = document.createElement('span');
+    keySpan.className = 'issue-key';
+    keySpan.textContent = issue.issueKey + ' ';
+
+    const domainSmall = document.createElement('small');
+    domainSmall.style.color = '#6b778c';
+    domainSmall.style.fontWeight = 'normal';
+    domainSmall.textContent = `(${domain})`;
+
+    keySpan.appendChild(domainSmall);
+
+    const titleSpan = document.createElement('span');
+    titleSpan.className = 'issue-title';
+    titleSpan.textContent = issue.title;
+
+    content.appendChild(keySpan);
+    content.appendChild(titleSpan);
+
+    item.appendChild(indicators);
+    item.appendChild(content);
 
     item.addEventListener('click', () => {
       handleIssueClick(issue);
@@ -36,12 +63,6 @@ async function renderList() {
 
     listElement.appendChild(item);
   });
-}
-
-function escapeHtml(str) {
-  const div = document.createElement('div');
-  div.textContent = str;
-  return div.innerHTML;
 }
 
 async function handleIssueClick(issue) {


### PR DESCRIPTION
Jiraの課題管理において、タブの紐付けが正しく更新されない不具合と、コメント入力後に編集中マーク（鉛筆マーク）が消えない不具合を修正しました。

主な変更点：
1. **タブ管理の改善**: 同じタブで別のJira課題に遷移した際、以前の課題の「開いている」ステータスを正しく解除するように修正しました。また、タブを閉じた際に関連するすべての課題の状態を更新するようにしました。
2. **編集状態検知の強化**: 従来のタイマーベースの検知を廃止し、フォーカスの移動、Escapeキーによるキャンセル、Ctrl+Enterによる保存、およびボタンクリックを検知するイベントベースのロジックに刷新しました。
3. **セキュリティと規約への準拠**: sidepanel.jsにおいてinnerHTMLの使用を禁止する規約に従い、DOM操作をcreateElement/textContentに書き換えました。
4. **バージョンアップ**: 修正を反映し、v0.2.1に更新しました。

---
*PR created automatically by Jules for task [17362760864533174998](https://jules.google.com/task/17362760864533174998) started by @masanori-satake*