### PR TITLE
Data Center版JIRAへの対応とホスト設定機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.2.3-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.3.0-blue)](manifest.json)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)
 

--- a/db.js
+++ b/db.js
@@ -105,4 +105,28 @@ export class IssuesDB {
       request.onerror = () => reject(request.error);
     });
   }
+
+  async getSettings() {
+    return new Promise((resolve) => {
+      chrome.storage.local.get(['settings'], (result) => {
+        if (result.settings) {
+          resolve(result.settings);
+        } else {
+          const defaultSettings = [
+            { id: Date.now().toString(), name: 'Jira Cloud', url: 'atlassian.net', visible: true }
+          ];
+          chrome.storage.local.set({ settings: defaultSettings });
+          resolve(defaultSettings);
+        }
+      });
+    });
+  }
+
+  async setSettings(settings) {
+    return new Promise((resolve) => {
+      chrome.storage.local.set({ settings }, () => {
+        resolve();
+      });
+    });
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Issues-Solo",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "permissions": [
     "sidePanel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "./scripts/build.sh"

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -19,7 +19,7 @@ body {
 }
 
 header {
-  padding: 12px 16px;
+  padding: 8px 16px;
   background-color: var(--header-bg);
   border-bottom: 1px solid var(--border-color);
   position: sticky;
@@ -27,14 +27,42 @@ header {
   z-index: 10;
 }
 
-header h1 {
-  margin: 0;
-  font-size: 18px;
-  font-weight: 600;
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 32px;
+}
+
+.spacer {
+  flex-grow: 1;
+}
+
+.icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s;
+  color: var(--secondary-text);
+}
+
+.icon-btn:hover {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.icon-btn svg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
 }
 
 #issue-list {
-  padding: 8px 0;
+  padding: 0;
 }
 
 .issue-item {
@@ -100,6 +128,255 @@ header h1 {
   padding: 20px;
   text-align: center;
   color: var(--secondary-text);
+}
+
+.host-group-header {
+  background-color: #f0f2f5;
+  padding: 4px 16px;
+  font-size: 11px;
+  font-weight: bold;
+  color: var(--secondary-text);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+/* Settings Overlay */
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.settings-content {
+  background-color: var(--bg-color);
+  width: 90%;
+  max-width: 320px;
+  height: 80%;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.settings-header {
+  padding: 8px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+  padding: 0 8px;
+}
+
+.tab-btn {
+  background: none;
+  border: none;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--secondary-text);
+  border-bottom: 2px solid transparent;
+}
+
+.tab-btn.active {
+  color: #0052cc;
+  border-bottom-color: #0052cc;
+  font-weight: bold;
+}
+
+.tab-content {
+  flex-grow: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+/* Host List */
+#host-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.host-item {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  border-radius: 8px;
+  gap: 8px;
+  background-color: #fff;
+  margin-bottom: 4px;
+  border: 1px solid transparent;
+}
+
+.host-item.dragging {
+  opacity: 0.5;
+  border: 1px dashed var(--border-color);
+}
+
+.drag-handle {
+  cursor: grab;
+  color: #ccc;
+  display: flex;
+  align-items: center;
+}
+
+.drag-handle svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
+
+.host-info {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.host-name {
+  font-weight: bold;
+  font-size: 13px;
+}
+
+.host-url-preview {
+  font-size: 11px;
+  color: var(--secondary-text);
+}
+
+.visibility-toggle {
+  cursor: pointer;
+  color: var(--secondary-text);
+}
+
+.visibility-toggle svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+/* Host Actions */
+.host-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 16px 0;
+}
+
+.fab-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background-color: #d1e4ff;
+  color: #001d36;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.fab-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.fab-btn.secondary {
+  background-color: #f4f5f7;
+  color: var(--text-color);
+}
+
+.fab-btn svg {
+  width: 24px;
+  height: 24px;
+  fill: currentColor;
+}
+
+/* Dialogs */
+.dialog {
+  background-color: var(--bg-color);
+  padding: 20px;
+  border-radius: 16px;
+  width: 80%;
+  max-width: 280px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.dialog h3 {
+  margin-top: 0;
+  font-size: 18px;
+}
+
+.input-field {
+  margin-bottom: 16px;
+}
+
+.input-field label {
+  display: block;
+  font-size: 12px;
+  color: var(--secondary-text);
+  margin-bottom: 4px;
+}
+
+.input-field input {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.text-btn {
+  background: none;
+  border: none;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-weight: bold;
+  color: #0052cc;
+  border-radius: 4px;
+}
+
+.text-btn:hover {
+  background-color: rgba(0, 82, 204, 0.05);
+}
+
+.text-btn.danger {
+  color: #de350b;
+}
+
+.text-btn.danger:hover {
+  background-color: rgba(222, 53, 11, 0.05);
+}
+
+.about-container {
+  line-height: 1.6;
+}
+
+.about-container h3 {
+  margin-top: 0;
+}
+
+.about-container ul {
+  padding-left: 20px;
 }
 
 .no-history {

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -7,12 +7,90 @@
 </head>
 <body>
   <header>
-    <h1>Issues-Solo</h1>
+    <div class="header-content">
+      <div class="spacer"></div>
+      <button id="settings-btn" title="設定" class="icon-btn">
+        <svg viewBox="0 0 24 24"><path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/></svg>
+      </button>
+    </div>
   </header>
+
   <main id="issue-list">
     <!-- 履歴がここに動的に生成される -->
-    <div class="loading">Loading history...</div>
+    <div class="loading">履歴を読み込み中...</div>
   </main>
+
+  <div id="settings-panel" class="overlay hidden">
+    <div class="settings-content">
+      <div class="settings-header">
+        <button id="close-settings" class="icon-btn">
+          <svg viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>
+        </button>
+        <div class="tabs">
+          <button class="tab-btn active" data-tab="general">一般</button>
+          <button class="tab-btn" data-tab="about">About</button>
+        </div>
+      </div>
+      <div class="tab-content" id="general-tab">
+        <div class="host-list-container">
+          <ul id="host-list"></ul>
+        </div>
+        <div class="host-actions">
+          <button id="add-host-btn" class="fab-btn" title="追加">
+            <svg viewBox="0 0 24 24"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
+          </button>
+          <button id="delete-host-btn" class="fab-btn secondary" title="削除" disabled>
+            <svg viewBox="0 0 24 24"><path d="M19 13H5v-2h14v2z"/></svg>
+          </button>
+        </div>
+      </div>
+      <div class="tab-content hidden" id="about-tab">
+        <div class="about-container">
+          <h3>Issues-Solo</h3>
+          <p>Version <span id="extension-version">0.3.0</span></p>
+          <p>JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能</p>
+          <hr>
+          <p>この拡張機能は、プライバシーを最優先に設計されています。すべてのデータはあなたのブラウザ内にのみ保存され、外部サーバーに送信されることはありません。</p>
+          <p>Soloシリーズ：</p>
+          <ul>
+            <li>Replace-Solo</li>
+            <li>QuickLog-Solo</li>
+            <li>Issues-Solo</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="add-host-dialog" class="overlay hidden">
+    <div class="dialog">
+      <h3>Jiraホストの追加</h3>
+      <div class="input-field">
+        <label for="host-name">表示名</label>
+        <input type="text" id="host-name" placeholder="例: 社内Jira">
+      </div>
+      <div class="input-field">
+        <label for="host-url">URL / ドメイン</label>
+        <input type="text" id="host-url" placeholder="例: jira.example.com">
+      </div>
+      <div class="dialog-actions">
+        <button id="cancel-add-host" class="text-btn">キャンセル</button>
+        <button id="confirm-add-host" class="text-btn">追加</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="delete-confirm-dialog" class="overlay hidden">
+    <div class="dialog">
+      <h3>ホストの削除</h3>
+      <p>選択したホストを削除してもよろしいですか？（履歴データは保持されますが、リストには表示されなくなります）</p>
+      <div class="dialog-actions">
+        <button id="cancel-delete-host" class="text-btn">キャンセル</button>
+        <button id="confirm-delete-host" class="text-btn danger">削除</button>
+      </div>
+    </div>
+  </div>
+
   <script type="module" src="sidepanel.js"></script>
 </body>
 </html>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2,67 +2,120 @@ import { IssuesDB } from './db.js';
 
 const db = new IssuesDB();
 const listElement = document.getElementById('issue-list');
+const settingsBtn = document.getElementById('settings-btn');
+const settingsPanel = document.getElementById('settings-panel');
+const closeSettingsBtn = document.getElementById('close-settings');
+const tabButtons = document.querySelectorAll('.tab-btn');
+const tabContents = document.querySelectorAll('.tab-content');
+const hostList = document.getElementById('host-list');
+const addHostBtn = document.getElementById('add-host-btn');
+const deleteHostBtn = document.getElementById('delete-host-btn');
+const addHostDialog = document.getElementById('add-host-dialog');
+const cancelAddHostBtn = document.getElementById('cancel-add-host');
+const confirmAddHostBtn = document.getElementById('confirm-add-host');
+const hostNameInput = document.getElementById('host-name');
+const hostUrlInput = document.getElementById('host-url');
+const deleteConfirmDialog = document.getElementById('delete-confirm-dialog');
+const cancelDeleteHostBtn = document.getElementById('cancel-delete-host');
+const confirmDeleteHostBtn = document.getElementById('confirm-delete-host');
+
+let selectedHostIds = new Set();
+let currentSettings = [];
 
 async function renderList() {
   const issues = await db.getAllIssues();
+  const settings = await db.getSettings();
+  currentSettings = settings;
 
   if (issues.length === 0) {
-    listElement.innerHTML = '<div class="no-history">No history found.</div>';
+    listElement.textContent = '';
+    const noHistory = document.createElement('div');
+    noHistory.className = 'no-history';
+    noHistory.textContent = '履歴が見つかりません。';
+    listElement.appendChild(noHistory);
     return;
   }
 
   listElement.textContent = '';
-  issues.forEach(issue => {
-    const item = document.createElement('div');
-    item.className = 'issue-item';
 
-    // インスタンスを区別するためにドメインを表示
-    const domain = new URL(issue.url).hostname;
+  const visibleSettings = settings.filter(s => s.visible);
+  const showHeaders = visibleSettings.length > 1;
 
-    const indicators = document.createElement('div');
-    indicators.className = 'status-indicators';
-
-    const openIndicator = document.createElement('div');
-    openIndicator.className = `indicator ${issue.isOpened ? 'is-opened' : ''}`;
-    openIndicator.title = issue.isOpened ? 'Tab is open' : 'Tab is closed';
-
-    const editIndicator = document.createElement('div');
-    editIndicator.className = `indicator ${issue.isEditing ? 'is-editing' : ''}`;
-    editIndicator.title = issue.isEditing ? 'Currently editing' : '';
-
-    indicators.appendChild(openIndicator);
-    indicators.appendChild(editIndicator);
-
-    const content = document.createElement('div');
-    content.className = 'issue-content';
-
-    const keySpan = document.createElement('span');
-    keySpan.className = 'issue-key';
-    keySpan.textContent = issue.issueKey + ' ';
-
-    const domainSmall = document.createElement('small');
-    domainSmall.style.color = '#6b778c';
-    domainSmall.style.fontWeight = 'normal';
-    domainSmall.textContent = `(${domain})`;
-
-    keySpan.appendChild(domainSmall);
-
-    const titleSpan = document.createElement('span');
-    titleSpan.className = 'issue-title';
-    titleSpan.textContent = issue.title;
-
-    content.appendChild(keySpan);
-    content.appendChild(titleSpan);
-
-    item.appendChild(indicators);
-    item.appendChild(content);
-
-    item.addEventListener('click', () => {
-      handleIssueClick(issue);
+  visibleSettings.forEach(host => {
+    const hostIssues = issues.filter(issue => {
+      try {
+        const url = new URL(issue.url);
+        return url.hostname.includes(host.url);
+      } catch (e) {
+        return false;
+      }
     });
 
-    listElement.appendChild(item);
+    if (hostIssues.length > 0) {
+      if (showHeaders) {
+        const header = document.createElement('div');
+        header.className = 'host-group-header';
+        header.textContent = host.name;
+        listElement.appendChild(header);
+      }
+
+      hostIssues.forEach(issue => {
+        const item = createIssueItem(issue);
+        listElement.appendChild(item);
+      });
+    }
   });
+}
+
+function createIssueItem(issue) {
+  const item = document.createElement('div');
+  item.className = 'issue-item';
+
+  const domain = new URL(issue.url).hostname;
+
+  const indicators = document.createElement('div');
+  indicators.className = 'status-indicators';
+
+  const openIndicator = document.createElement('div');
+  openIndicator.className = `indicator ${issue.isOpened ? 'is-opened' : ''}`;
+  openIndicator.title = issue.isOpened ? 'タブが開いています' : 'タブは閉じています';
+
+  const editIndicator = document.createElement('div');
+  editIndicator.className = `indicator ${issue.isEditing ? 'is-editing' : ''}`;
+  editIndicator.title = issue.isEditing ? '編集中' : '';
+
+  indicators.appendChild(openIndicator);
+  indicators.appendChild(editIndicator);
+
+  const content = document.createElement('div');
+  content.className = 'issue-content';
+
+  const keySpan = document.createElement('span');
+  keySpan.className = 'issue-key';
+  keySpan.textContent = issue.issueKey + ' ';
+
+  const domainSmall = document.createElement('small');
+  domainSmall.style.color = '#6b778c';
+  domainSmall.style.fontWeight = 'normal';
+  domainSmall.textContent = `(${domain})`;
+
+  keySpan.appendChild(domainSmall);
+
+  const titleSpan = document.createElement('span');
+  titleSpan.className = 'issue-title';
+  titleSpan.textContent = issue.title;
+
+  content.appendChild(keySpan);
+  content.appendChild(titleSpan);
+
+  item.appendChild(indicators);
+  item.appendChild(content);
+
+  item.addEventListener('click', () => {
+    handleIssueClick(issue);
+  });
+
+  return item;
 }
 
 async function handleIssueClick(issue) {
@@ -78,6 +131,170 @@ async function handleIssueClick(issue) {
     chrome.tabs.create({ url: issue.url });
   }
 }
+
+// Settings Logic
+settingsBtn.addEventListener('click', () => {
+  settingsPanel.classList.remove('hidden');
+  renderHostSettings();
+});
+
+closeSettingsBtn.addEventListener('click', () => {
+  settingsPanel.classList.add('hidden');
+});
+
+tabButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const tabName = btn.dataset.tab;
+    tabButtons.forEach(b => b.classList.toggle('active', b === btn));
+    tabContents.forEach(c => c.classList.toggle('hidden', c.id !== `${tabName}-tab`));
+  });
+});
+
+async function renderHostSettings() {
+  const settings = await db.getSettings();
+  currentSettings = settings;
+  hostList.textContent = '';
+
+  settings.forEach((host, index) => {
+    const li = document.createElement('li');
+    li.className = 'host-item';
+    li.dataset.id = host.id;
+    li.draggable = true;
+
+    const dragHandle = document.createElement('div');
+    dragHandle.className = 'drag-handle';
+    dragHandle.innerHTML = '<svg viewBox="0 0 24 24"><path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = selectedHostIds.has(host.id);
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) {
+        selectedHostIds.add(host.id);
+      } else {
+        selectedHostIds.delete(host.id);
+      }
+      deleteHostBtn.disabled = selectedHostIds.size === 0;
+    });
+
+    const info = document.createElement('div');
+    info.className = 'host-info';
+
+    const name = document.createElement('span');
+    name.className = 'host-name';
+    name.textContent = host.name;
+
+    const url = document.createElement('span');
+    url.className = 'host-url-preview';
+    url.textContent = host.url;
+
+    info.appendChild(name);
+    info.appendChild(url);
+
+    const toggle = document.createElement('div');
+    toggle.className = 'visibility-toggle';
+    toggle.title = host.visible ? '表示中' : '非表示';
+    toggle.innerHTML = host.visible
+      ? '<svg viewBox="0 0 24 24"><path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/></svg>'
+      : '<svg viewBox="0 0 24 24"><path d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.82l2.92 2.92c1.51-1.39 2.59-3.21 3.44-5.24-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46C3.08 8.3 1.78 10.02 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78l3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z"/></svg>';
+
+    toggle.addEventListener('click', async () => {
+      host.visible = !host.visible;
+      await db.setSettings(settings);
+      renderHostSettings();
+      renderList();
+    });
+
+    li.appendChild(dragHandle);
+    li.appendChild(checkbox);
+    li.appendChild(info);
+    li.appendChild(toggle);
+
+    // Drag and Drop
+    li.addEventListener('dragstart', (e) => {
+      li.classList.add('dragging');
+      e.dataTransfer.setData('text/plain', index);
+    });
+
+    li.addEventListener('dragend', () => {
+      li.classList.remove('dragging');
+    });
+
+    hostList.appendChild(li);
+  });
+}
+
+// Drag and Drop global listeners to avoid duplication
+hostList.addEventListener('dragover', (e) => {
+  e.preventDefault();
+  const draggingItem = document.querySelector('.dragging');
+  if (!draggingItem) return;
+
+  const siblings = [...hostList.querySelectorAll('.host-item:not(.dragging)')];
+  const nextSibling = siblings.find(sibling => {
+    return e.clientY <= sibling.offsetTop + sibling.offsetHeight / 2;
+  });
+  hostList.insertBefore(draggingItem, nextSibling);
+});
+
+hostList.addEventListener('drop', async (e) => {
+  e.preventDefault();
+  const newSettings = [...hostList.querySelectorAll('.host-item')].map(item => {
+    return currentSettings.find(s => s.id === item.dataset.id);
+  });
+  await db.setSettings(newSettings);
+  currentSettings = newSettings;
+  renderList();
+});
+
+// Add Host
+addHostBtn.addEventListener('click', () => {
+  addHostDialog.classList.remove('hidden');
+  hostNameInput.value = '';
+  hostUrlInput.value = '';
+});
+
+cancelAddHostBtn.addEventListener('click', () => {
+  addHostDialog.classList.add('hidden');
+});
+
+confirmAddHostBtn.addEventListener('click', async () => {
+  const name = hostNameInput.value.trim();
+  const url = hostUrlInput.value.trim();
+  if (name && url) {
+    const settings = await db.getSettings();
+    settings.push({
+      id: Date.now().toString(),
+      name,
+      url,
+      visible: true
+    });
+    await db.setSettings(settings);
+    addHostDialog.classList.add('hidden');
+    renderHostSettings();
+    renderList();
+  }
+});
+
+// Delete Host
+deleteHostBtn.addEventListener('click', () => {
+  deleteConfirmDialog.classList.remove('hidden');
+});
+
+cancelDeleteHostBtn.addEventListener('click', () => {
+  deleteConfirmDialog.classList.add('hidden');
+});
+
+confirmDeleteHostBtn.addEventListener('click', async () => {
+  let settings = await db.getSettings();
+  settings = settings.filter(s => !selectedHostIds.has(s.id));
+  await db.setSettings(settings);
+  selectedHostIds.clear();
+  deleteHostBtn.disabled = true;
+  deleteConfirmDialog.classList.add('hidden');
+  renderHostSettings();
+  renderList();
+});
 
 chrome.runtime.onMessage.addListener((message) => {
   if (message.type === 'DB_UPDATED') {

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -45,7 +45,7 @@ async function renderList() {
     const hostIssues = issues.filter(issue => {
       try {
         const url = new URL(issue.url);
-        return url.hostname.includes(host.url);
+        return url.hostname === host.url || url.hostname.endsWith('.' + host.url);
       } catch (e) {
         return false;
       }
@@ -260,8 +260,16 @@ cancelAddHostBtn.addEventListener('click', () => {
 
 confirmAddHostBtn.addEventListener('click', async () => {
   const name = hostNameInput.value.trim();
-  const url = hostUrlInput.value.trim();
+  let url = hostUrlInput.value.trim();
   if (name && url) {
+    try {
+      if (url.includes('://')) {
+        url = new URL(url).hostname;
+      }
+    } catch (e) {
+      // If parsing fails, keep the original trimmed input
+    }
+
     const settings = await db.getSettings();
     settings.push({
       id: Date.now().toString(),


### PR DESCRIPTION
JIRA Data Center版への対応として、任意のJIRAホストを登録・管理できる機能を追加しました。サイドパネルに設定画面を実装し、ホストの追加・削除、表示順序の変更、表示/非表示の切り替えが可能です。また、課題リストを登録されたホストごとにグループ表示するようにしました。デザインはMaterial 3に基づき、Soloシリーズの他の拡張機能と統一しています。

Fixes #8

---
*PR created automatically by Jules for task [1026882066430210996](https://jules.google.com/task/1026882066430210996) started by @masanori-satake*