### PR TITLE
JiraホストごとのIssuesリストを折り畳み可能にする機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.3.0-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.4.0-blue)](manifest.json)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Issues-Solo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "permissions": [
     "sidePanel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/build.py"

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -132,13 +132,39 @@ header {
 
 .host-group-header {
   background-color: #f0f2f5;
-  padding: 4px 16px;
+  padding: 6px 16px;
   font-size: 11px;
   font-weight: bold;
   color: var(--secondary-text);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   border-bottom: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.host-group-header.clickable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.host-group-header.clickable:hover {
+  background-color: #e2e4e9;
+}
+
+.collapse-glyph {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+}
+
+.collapse-glyph svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
 }
 
 /* Settings Overlay */

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -47,7 +47,7 @@
       <div class="tab-content hidden" id="about-tab">
         <div class="about-container">
           <h3>Issues-Solo</h3>
-          <p>Version <span id="extension-version">0.3.0</span></p>
+          <p>Version <span id="extension-version">0.4.0</span></p>
           <p>JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能</p>
           <hr>
           <p>この拡張機能は、プライバシーを最優先に設計されています。すべてのデータはあなたのブラウザ内にのみ保存され、外部サーバーに送信されることはありません。</p>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -53,36 +53,34 @@ async function renderList() {
     return { host, issues: hostIssues };
   }).filter(group => group.issues.length > 0);
 
-  const showHeaders = visibleSettings.length > 1;
-  const showGlyphs = hostGroups.length > 1;
+  const useAccordion = hostGroups.length > 1;
 
   hostGroups.forEach(({ host, issues: hostIssues }) => {
-    if (showHeaders) {
+    if (useAccordion) {
       const header = document.createElement('div');
-      header.className = 'host-group-header';
-      if (showGlyphs) {
-        header.classList.add('clickable');
-        const glyph = document.createElement('span');
-        glyph.className = 'collapse-glyph';
-        const isCollapsed = host.isCollapsed || false;
-        glyph.innerHTML = isCollapsed
-          ? '<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>' // 右向き
-          : '<svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>'; // 下向き
-        header.appendChild(glyph);
+      header.className = 'host-group-header clickable';
 
-        header.addEventListener('click', async () => {
-          host.isCollapsed = !host.isCollapsed;
-          await db.setSettings(settings);
-          renderList();
-        });
-      }
+      const glyph = document.createElement('span');
+      glyph.className = 'collapse-glyph';
+      const isCollapsed = !!host.isCollapsed;
+      glyph.innerHTML = isCollapsed
+        ? '<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>' // 右向き
+        : '<svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>'; // 下向き
+      header.appendChild(glyph);
+
+      header.addEventListener('click', async () => {
+        host.isCollapsed = !host.isCollapsed;
+        await db.setSettings(settings);
+        renderList();
+      });
+
       const name = document.createElement('span');
       name.textContent = host.name;
       header.appendChild(name);
       listElement.appendChild(header);
     }
 
-    if (!showGlyphs || !host.isCollapsed) {
+    if (!useAccordion || !host.isCollapsed) {
       hostIssues.forEach(issue => {
         const item = createIssueItem(issue);
         listElement.appendChild(item);

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -39,9 +39,9 @@ async function renderList() {
   listElement.textContent = '';
 
   const visibleSettings = settings.filter(s => s.visible);
-  const showHeaders = visibleSettings.length > 1;
 
-  visibleSettings.forEach(host => {
+  // 各ホストのIssueをあらかじめ抽出
+  const hostGroups = visibleSettings.map(host => {
     const hostIssues = issues.filter(issue => {
       try {
         const url = new URL(issue.url);
@@ -50,15 +50,39 @@ async function renderList() {
         return false;
       }
     });
+    return { host, issues: hostIssues };
+  }).filter(group => group.issues.length > 0);
 
-    if (hostIssues.length > 0) {
-      if (showHeaders) {
-        const header = document.createElement('div');
-        header.className = 'host-group-header';
-        header.textContent = host.name;
-        listElement.appendChild(header);
+  const showHeaders = visibleSettings.length > 1;
+  const showGlyphs = hostGroups.length > 1;
+
+  hostGroups.forEach(({ host, issues: hostIssues }) => {
+    if (showHeaders) {
+      const header = document.createElement('div');
+      header.className = 'host-group-header';
+      if (showGlyphs) {
+        header.classList.add('clickable');
+        const glyph = document.createElement('span');
+        glyph.className = 'collapse-glyph';
+        const isCollapsed = host.isCollapsed || false;
+        glyph.innerHTML = isCollapsed
+          ? '<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>' // 右向き
+          : '<svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>'; // 下向き
+        header.appendChild(glyph);
+
+        header.addEventListener('click', async () => {
+          host.isCollapsed = !host.isCollapsed;
+          await db.setSettings(settings);
+          renderList();
+        });
       }
+      const name = document.createElement('span');
+      name.textContent = host.name;
+      header.appendChild(name);
+      listElement.appendChild(header);
+    }
 
+    if (!showGlyphs || !host.isCollapsed) {
       hostIssues.forEach(issue => {
         const item = createIssueItem(issue);
         listElement.appendChild(item);


### PR DESCRIPTION
JiraホストごとのIssuesリストを折り畳み可能にする機能を実装しました。
複数のホストが表示されている場合、各ホストのヘッダーをクリックすることで、そのホストに属するIssueのリストを表示・非表示に切り替えることができます。
この開閉状態は保存され、ブラウザの再起動後も維持されます。
また、プロジェクトのガイドラインに従い、バージョンを0.4.0に更新しました。

---
*PR created automatically by Jules for task [7183175983969075060](https://jules.google.com/task/7183175983969075060) started by @masanori-satake*