### PR TITLE
Jira Cloudデータ抽出修正とインストール時自動読み込み対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.5.0-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.5.1-blue)](manifest.json)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)
 

--- a/background.js
+++ b/background.js
@@ -30,7 +30,22 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
 
 chrome.runtime.onInstalled.addListener(async () => {
   // すべての JIRA インスタンスを対象にクエリ
-  const tabs = await chrome.tabs.query({ url: "*://*/browse/*" });
+  const tabs = await chrome.tabs.query({
+    url: ["https://*.atlassian.net/browse/*", "https://*/browse/*"]
+  });
+
+  // インストール時に既存のタブに content.js を注入する
+  for (const tab of tabs) {
+    try {
+      await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        files: ['content.js']
+      });
+    } catch (e) {
+      console.error(`Failed to inject content script into tab ${tab.id}:`, e);
+    }
+  }
+
   const openTabIds = new Set(tabs.map(t => t.id));
 
   const issues = await db.getAllIssues();

--- a/background.js
+++ b/background.js
@@ -42,7 +42,8 @@ chrome.runtime.onInstalled.addListener(async () => {
         files: ['content.js']
       });
     } catch (e) {
-      console.error(`Failed to inject content script into tab ${tab.id}:`, e);
+      // 権限のないページや特殊なタブでは注入に失敗する場合があるが、
+      // ユーザーへの影響はないため、エラー出力は抑制する
     }
   }
 

--- a/content.js
+++ b/content.js
@@ -39,19 +39,30 @@
    * DOMから優先度を取得する
    */
   const getPriority = () => {
-    // Cloud
-    const cloudPriority = document.querySelector('[data-testid="issue.views.issue-base.foundation.priority.priority-view"]');
-    if (cloudPriority) {
-      // <img>タグのalt属性を確認
-      const img = cloudPriority.querySelector('img');
-      if (img && img.getAttribute('alt')) return img.getAttribute('alt');
+    // Cloud: 複数のセレクタ候補を試行（チーム管理対象プロジェクト等への対応）
+    const cloudPrioritySelectors = [
+      '[data-testid="issue.views.issue-base.foundation.priority.priority-view"]',
+      '[data-testid="issue-field-priority.ui.priority-view.priority-wrapper"]',
+      '[data-testid*="priority-view"]',
+      '[data-testid*="priority-field"]'
+    ];
 
-      // <svg>タグのaria-labelを確認（Jira Cloudの新しいUI対応）
-      const svg = cloudPriority.querySelector('svg');
-      if (svg && svg.getAttribute('aria-label')) return svg.getAttribute('aria-label');
+    for (const selector of cloudPrioritySelectors) {
+      const el = document.querySelector(selector);
+      if (el) {
+        // <img>タグのalt属性を確認
+        const img = el.querySelector('img');
+        if (img && img.getAttribute('alt')) return img.getAttribute('alt');
 
-      return cloudPriority.innerText.trim();
+        // <svg>タグのaria-labelを確認（Jira Cloudの新しいUI対応）
+        const svg = el.querySelector('svg');
+        if (svg && svg.getAttribute('aria-label')) return svg.getAttribute('aria-label');
+
+        const text = el.innerText.trim();
+        if (text && text !== '優先度' && text !== 'Priority') return text;
+      }
     }
+
     // Data Center
     const dcPriority = document.querySelector('#priority-val');
     if (dcPriority) {
@@ -66,11 +77,24 @@
    * DOMからステータスを取得する
    */
   const getStatus = () => {
-    // Cloud
-    const cloudStatus = document.querySelector('[data-testid="issue.views.issue-base.foundation.status.status-button-item"]');
-    if (cloudStatus && cloudStatus.innerText.trim()) {
-      return cloudStatus.innerText.trim();
+    // Cloud: 複数のセレクタ候補を試行（ステータスボタン、ピッカーなど）
+    const cloudStatusSelectors = [
+      '[data-testid="issue.views.issue-base.foundation.status.status-button-item"]',
+      '[data-testid="issue-field-status.ui.status-view.status-wrapper"]',
+      '[data-testid*="status.status-button-item"]',
+      '[data-testid*="status-view"]',
+      'button[aria-label*="Status"]',
+      'button[aria-label*="ステータス"]'
+    ];
+
+    for (const selector of cloudStatusSelectors) {
+      const el = document.querySelector(selector);
+      if (el) {
+        const text = el.innerText.trim();
+        if (text) return text;
+      }
     }
+
     // Data Center
     const dcStatus = document.querySelector('#status-val');
     if (dcStatus && dcStatus.innerText.trim()) {

--- a/content.js
+++ b/content.js
@@ -8,6 +8,11 @@
   };
 
   /**
+   * 抽出時に除外するラベル（フィールド名自体が取得された場合のフィルタリング用）
+   */
+  const EXCLUDED_LABELS = ['優先度', 'Priority', 'ステータス', 'Status'];
+
+  /**
    * DOMから課題の要約（Summary）を取得する
    * Cloud版とData Center版の両方に対応
    */
@@ -59,7 +64,7 @@
         if (svg && svg.getAttribute('aria-label')) return svg.getAttribute('aria-label');
 
         const text = el.innerText.trim();
-        if (text && text !== '優先度' && text !== 'Priority') return text;
+        if (text && !EXCLUDED_LABELS.includes(text)) return text;
       }
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Issues-Solo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "permissions": [
     "sidePanel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/build.py"

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -47,7 +47,7 @@
       <div class="tab-content hidden" id="about-tab">
         <div class="about-container">
           <h3>Issues-Solo</h3>
-          <p>Version <span id="extension-version">0.4.0</span></p>
+          <p>Version <span id="extension-version">0.5.1</span></p>
           <p>JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能</p>
           <hr>
           <p>この拡張機能は、プライバシーを最優先に設計されています。すべてのデータはあなたのブラウザ内にのみ保存され、外部サーバーに送信されることはありません。</p>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -389,6 +389,12 @@ confirmDeleteHostBtn.addEventListener('click', async () => {
   renderList();
 });
 
+// バージョン情報の表示
+const versionSpan = document.getElementById('extension-version');
+if (versionSpan) {
+  versionSpan.textContent = chrome.runtime.getManifest().version;
+}
+
 // DB更新通知の受信
 chrome.runtime.onMessage.addListener((message) => {
   if (message.type === 'DB_UPDATED') {


### PR DESCRIPTION
以下の不具合および改善に対応しました。

1. **インストール時の挙動改善**:
   拡張機能のインストール直後に、既に開いているJiraのタブがリストに表示されない問題を解決するため、`background.js` に `chrome.scripting.executeScript` を用いた自動注入処理を追加しました。

2. **Jira Cloudデータ抽出の強化**:
   Jira Cloud（特にチーム管理対象プロジェクト）において、ステータスや優先度がサイドパネルに表示されない問題を解決しました。`content.js` の取得ロジックにおいて、複数のセレクタ候補や `aria-label` を活用することで、UIの変化に強い抽出を実現しました。

3. **バージョン更新**:
   修正に伴い、`manifest.json`, `package.json`, `package-lock.json`, `README.md`, `sidepanel.html` のバージョンを `0.5.1` に更新しました。

---
*PR created automatically by Jules for task [9790209163512066684](https://jules.google.com/task/9790209163512066684) started by @masanori-satake*