### PR TITLE
優先度表示の不具合修正と取得ロジックの堅牢化

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.5.1-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.5.2-blue)](manifest.json)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)
 

--- a/content.js
+++ b/content.js
@@ -41,30 +41,70 @@
   };
 
   /**
+   * 優先度のキーワード一覧 (長いキーワードから順に判定)
+   */
+  const PRIORITY_KEYWORDS = [
+    'Highest', 'Lowest', 'Medium', 'High', 'Low',
+    '最高', '最低', '高', '中', '低'
+  ];
+
+  /**
    * DOMから優先度を取得する
    */
   const getPriority = () => {
-    // Cloud: 複数のセレクタ候補を試行（チーム管理対象プロジェクト等への対応）
+    // Cloud: 複数のセレクタ候補を試行
     const cloudPrioritySelectors = [
       '[data-testid="issue.views.issue-base.foundation.priority.priority-view"]',
       '[data-testid="issue-field-priority.ui.priority-view.priority-wrapper"]',
       '[data-testid*="priority-view"]',
-      '[data-testid*="priority-field"]'
+      '[data-testid*="priority-field"]',
+      '[data-testid*="priority.wrapper"]'
     ];
 
     for (const selector of cloudPrioritySelectors) {
-      const el = document.querySelector(selector);
-      if (el) {
-        // <img>タグのalt属性を確認
+      const elements = document.querySelectorAll(selector);
+      for (const el of elements) {
+        // 1. <img>タグのalt属性を確認
         const img = el.querySelector('img');
         if (img && img.getAttribute('alt')) return img.getAttribute('alt');
 
-        // <svg>タグのaria-labelを確認（Jira Cloudの新しいUI対応）
+        // 2. <img>タグのsrcから推測 (altが空の場合の対応)
+        if (img && img.getAttribute('src')) {
+          const src = img.getAttribute('src').toLowerCase();
+          // 長いキーワードから順に判定することで「low」が「lowest」に部分一致するのを防ぐ
+          for (const kw of ['highest', 'lowest', 'medium', 'high', 'low']) {
+            if (src.includes(kw)) {
+              return kw.charAt(0).toUpperCase() + kw.slice(1);
+            }
+          }
+        }
+
+        // 3. <svg>タグのaria-labelを確認
         const svg = el.querySelector('svg');
         if (svg && svg.getAttribute('aria-label')) return svg.getAttribute('aria-label');
 
-        const text = el.innerText.trim();
-        if (text && !EXCLUDED_LABELS.includes(text)) return text;
+        // 4. テキスト内容からキーワードを抽出
+        let text = el.innerText || '';
+        // 不要なラベルを除去
+        for (const label of EXCLUDED_LABELS) {
+          text = text.replace(label, '');
+        }
+        text = text.trim();
+
+        if (text) {
+          // キーワードがそのまま含まれているか確認
+          for (const kw of PRIORITY_KEYWORDS) {
+            if (text.includes(kw)) return kw;
+          }
+          // 特殊ケース：改行などで区切られている場合、最後の行が値である可能性が高い
+          const lines = text.split('\n').map(l => l.trim()).filter(l => l);
+          if (lines.length > 0) {
+            const lastLine = lines[lines.length - 1];
+            if (PRIORITY_KEYWORDS.includes(lastLine)) return lastLine;
+          }
+
+          if (!EXCLUDED_LABELS.includes(text)) return text;
+        }
       }
     }
 
@@ -93,10 +133,27 @@
     ];
 
     for (const selector of cloudStatusSelectors) {
-      const el = document.querySelector(selector);
-      if (el) {
-        const text = el.innerText.trim();
-        if (text) return text;
+      const elements = document.querySelectorAll(selector);
+      for (const el of elements) {
+        let text = el.innerText || '';
+        // 不要なラベルを除去
+        for (const label of EXCLUDED_LABELS) {
+          text = text.replace(label, '');
+        }
+        text = text.trim();
+
+        // Jiraのステータスボタンなどは改行を含んで「ステータス\n完了」のようになっていることがある
+        const lines = text.split('\n').map(l => l.trim()).filter(l => l);
+        if (lines.length > 0) {
+          // 最も長い行か、最後の行をステータス名として採用する可能性が高い
+          // ここでは最後の行を採用（Jiraの一般的な構造に準拠）
+          const statusCandidate = lines[lines.length - 1];
+          if (statusCandidate && !EXCLUDED_LABELS.includes(statusCandidate)) {
+            return statusCandidate;
+          }
+        }
+
+        if (text && !EXCLUDED_LABELS.includes(text)) return text;
       }
     }
 

--- a/content.js
+++ b/content.js
@@ -85,16 +85,16 @@
 
         // 4. テキスト内容からキーワードを抽出
         let text = el.innerText || '';
-        // 不要なラベルを除去
+        // 不要なラベルを除去 (大文字小文字を区別せず、全て置換)
         for (const label of EXCLUDED_LABELS) {
-          text = text.replace(label, '');
+          text = text.replace(new RegExp(label, 'gi'), '');
         }
         text = text.trim();
 
         if (text) {
-          // キーワードがそのまま含まれているか確認
+          // キーワードがそのまま含まれているか確認 (大文字小文字を区別しない)
           for (const kw of PRIORITY_KEYWORDS) {
-            if (text.includes(kw)) return kw;
+            if (new RegExp(kw, 'i').test(text)) return kw;
           }
           // 特殊ケース：改行などで区切られている場合、最後の行が値である可能性が高い
           const lines = text.split('\n').map(l => l.trim()).filter(l => l);
@@ -136,9 +136,9 @@
       const elements = document.querySelectorAll(selector);
       for (const el of elements) {
         let text = el.innerText || '';
-        // 不要なラベルを除去
+        // 不要なラベルを除去 (大文字小文字を区別せず、全て置換)
         for (const label of EXCLUDED_LABELS) {
-          text = text.replace(label, '');
+          text = text.replace(new RegExp(label, 'gi'), '');
         }
         text = text.trim();
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Issues-Solo",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "permissions": [
     "sidePanel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/build.py"


### PR DESCRIPTION
Jira Cloudにおいて優先度が正しく表示されない（グレーの点になる）問題を修正しました。

主な変更点：
1. **取得ロジックの強化**: 従来の `querySelector` では最初に見つかったラベル要素（空のテキストを持つものなど）で探索が止まっていましたが、`querySelectorAll` を使用して全ての候補を検証するようにし、有効な値が見つかるまで探索を継続します。
2. **画像URLからの推測**: ユーザーから提供されたHTMLで `img` の `alt` 属性が空だったため、`src` 属性のURL（例: `highest_new.svg`）から優先度を特定するロジックを追加しました。
3. **キーワードマッチングの改善**: 「優先度」などのラベルがテキストに含まれる場合でも、それを除去して純粋なキーワード（Highest, Lowest等）を抽出します。また、「Lowest」が「Low」に部分一致して誤判定されないよう、判定順序を調整しました。
4. **ステータス表示の改善**: 優先度と同様の堅牢化をステータス取得にも適用し、複数行にわたるボタンテキストなどからの抽出精度を向上させました。
5. **バージョンアップ**: 修正に伴いバージョンを 0.5.2 に更新しました。

---
*PR created automatically by Jules for task [18292366455605607498](https://jules.google.com/task/18292366455605607498) started by @masanori-satake*