### PR TITLE
Data Center版Jiraのコンテキストパス対応とCloud版新UIへの対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.5.2-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.6.0-blue)](manifest.json)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)
 

--- a/background.js
+++ b/background.js
@@ -31,7 +31,7 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
 chrome.runtime.onInstalled.addListener(async () => {
   // すべての JIRA インスタンスを対象にクエリ
   const tabs = await chrome.tabs.query({
-    url: ["https://*.atlassian.net/browse/*", "https://*/browse/*"]
+    url: ["https://*.atlassian.net/*", "https://*/*"]
   });
 
   // インストール時に既存のタブに content.js を注入する

--- a/content.js
+++ b/content.js
@@ -1,9 +1,16 @@
 (function() {
   /**
+   * Data Center版のコンテキストパスやCloud新UIに対応するため、
+   * 広範なURLパターンで実行されるが、冒頭で課題キーの有無をチェックし
+   * 該当しないページでは即座に終了することで負荷を最小限に抑える。
+   */
+
+  /**
    * 現在のURLから課題キー（例: KAN-1）を抽出する
    */
   const getIssueKey = () => {
-    const match = window.location.pathname.match(/\/browse\/([A-Z0-9]+-[0-9]+)/);
+    // /browse/KEY or /issues/KEY に対応 (Data CenterやCloudの新UIに対応)
+    const match = window.location.pathname.match(/\/(?:browse|issues)\/([A-Z0-9]+-[0-9]+)/);
     return match ? match[1] : null;
   };
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Issues-Solo",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "permissions": [
     "sidePanel",
@@ -11,7 +11,7 @@
   ],
   "host_permissions": [
     "https://*.atlassian.net/*",
-    "https://*/browse/*"
+    "https://*/*"
   ],
   "background": {
     "service_worker": "background.js",
@@ -20,8 +20,8 @@
   "content_scripts": [
     {
       "matches": [
-        "https://*.atlassian.net/browse/*",
-        "https://*/browse/*"
+        "https://*.atlassian.net/*",
+        "https://*/*"
       ],
       "js": [
         "content.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/build.py"

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -82,7 +82,22 @@ async function renderList() {
     const hostIssues = issues.filter(issue => {
       try {
         const url = new URL(issue.url);
-        return url.hostname === host.url || url.hostname.endsWith('.' + host.url);
+        const hostUrl = host.url.toLowerCase();
+        const issueHostname = url.hostname.toLowerCase();
+        const issuePathname = url.pathname.toLowerCase();
+
+        // ホスト設定にパスが含まれている場合 (例: foo.bar.com/jira)
+        if (hostUrl.includes('/')) {
+          const [hostPart, ...pathParts] = hostUrl.split('/');
+          const pathPart = '/' + pathParts.join('/');
+          // パスセグメントとして一致することを確認 (例: /jira が /jira-test/ に前方一致しないようにする)
+          const isCorrectPath = issuePathname === pathPart || issuePathname.startsWith(pathPart + '/');
+          return (issueHostname === hostPart || issueHostname.endsWith('.' + hostPart)) &&
+                 isCorrectPath;
+        }
+
+        // ホスト名のみの場合
+        return issueHostname === hostUrl || issueHostname.endsWith('.' + hostUrl);
       } catch (e) {
         return false;
       }
@@ -349,7 +364,11 @@ confirmAddHostBtn.addEventListener('click', async () => {
   if (name && url) {
     try {
       if (url.includes('://')) {
-        url = new URL(url).hostname;
+        const parsedUrl = new URL(url);
+        // /browse/ や /issues/ より前のパスを保持する
+        const pathMatch = parsedUrl.pathname.match(/^(.*?)\/(?:browse|issues)/);
+        const contextPath = pathMatch ? pathMatch[1] : '';
+        url = parsedUrl.hostname + contextPath;
       }
     } catch (e) {
       // パース失敗時はトリミングした入力をそのまま使用


### PR DESCRIPTION
Data Center版Jiraにおいて、URLにコンテキストパス（例: `/jira/`）が含まれる場合に拡張機能が反応しない問題を修正しました。また、Cloud版の新しいUI（`/issues/`）にも対応しました。

主な変更点:
1.  **マニフェストの更新**: `host_permissions` と `content_scripts` のマッチパターンを `https://*/*` に広げ、Data Center版の多様なドメインとパス構成に対応しました。
2.  **課題キー抽出の改善**: `content.js` の正規表現を更新し、パスの途中に `/browse/` または `/issues/` があっても正しく課題キーを抽出できるようにしました。
3.  **ホスト管理の強化**: サイドパネルでのホスト追加時にコンテキストパスを保持し、表示時のフィルタリングにおいてパスセグメント単位で正確にマッチングするよう改善しました（例: `/jira` が `/jira-test` に誤一致しないように修正）。
4.  **バージョンアップ**: 機能拡張に伴い、バージョンを `0.6.0` に更新しました。

自動化された監査スクリプト（バージョン整合性、ポリシー準拠、ルートディレクトリの清潔さ）をすべてパスしていることを確認済みです。

Fixes #15

---
*PR created automatically by Jules for task [2881733436257777211](https://jules.google.com/task/2881733436257777211) started by @masanori-satake*