### PR TITLE
プロジェクトキーの設定およびグルーピング機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.6.0-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.7.0-blue)](manifest.json)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)
 

--- a/db.js
+++ b/db.js
@@ -129,4 +129,24 @@ export class IssuesDB {
       });
     });
   }
+
+  async getProjectSettings() {
+    return new Promise((resolve) => {
+      chrome.storage.local.get(['projectSettings'], (result) => {
+        if (result.projectSettings) {
+          resolve(result.projectSettings);
+        } else {
+          resolve([]);
+        }
+      });
+    });
+  }
+
+  async setProjectSettings(projectSettings) {
+    return new Promise((resolve) => {
+      chrome.storage.local.set({ projectSettings }, () => {
+        resolve();
+      });
+    });
+  }
 }

--- a/http_server.log
+++ b/http_server.log
@@ -1,0 +1,4 @@
+127.0.0.1 - - [24/Apr/2026 13:47:21] "GET /sidepanel.html HTTP/1.1" 200 -
+127.0.0.1 - - [24/Apr/2026 13:47:21] "GET /sidepanel.css HTTP/1.1" 200 -
+127.0.0.1 - - [24/Apr/2026 13:47:21] "GET /sidepanel.js HTTP/1.1" 200 -
+127.0.0.1 - - [24/Apr/2026 13:47:22] "GET /db.js HTTP/1.1" 200 -

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Issues-Solo",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "permissions": [
     "sidePanel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/build.py"

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -161,11 +161,11 @@ header {
 }
 
 .host-group-header {
-  background-color: #f0f2f5;
+  background-color: #0061A4; /* Material 3 Blue - Jira-like */
   padding: 6px 16px;
   font-size: 11px;
   font-weight: bold;
-  color: var(--secondary-text);
+  color: #FFFFFF;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   border-bottom: 1px solid var(--border-color);
@@ -180,7 +180,23 @@ header {
 }
 
 .host-group-header.clickable:hover {
-  background-color: #e2e4e9;
+  background-color: #004A7D;
+}
+
+.project-group-header {
+  padding: 6px 16px;
+  font-size: 12px;
+  font-weight: bold;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.project-group-header:hover {
+  filter: brightness(0.95);
 }
 
 .collapse-glyph {
@@ -324,11 +340,86 @@ header {
 }
 
 /* Host Actions */
-.host-actions {
+.host-actions, .project-actions {
   display: flex;
   justify-content: flex-end;
   gap: 12px;
   padding: 16px 0;
+}
+
+.project-list-container {
+  height: calc(48px * 3.5); /* 3.5 items height (assuming 48px per item) */
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow-y: scroll; /* Always show scrollbar */
+}
+
+#project-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.project-item {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  height: 48px;
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--border-color);
+  gap: 8px;
+  background-color: #fff;
+}
+
+.project-item:last-child {
+  border-bottom: none;
+}
+
+.project-item.dragging {
+  opacity: 0.5;
+  border: 1px dashed var(--border-color);
+}
+
+.project-key-label {
+  flex-grow: 1;
+  font-weight: bold;
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.color-picker {
+  display: flex;
+  gap: 4px;
+}
+
+.color-option {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+
+.color-option.selected {
+  border-color: #000;
+}
+
+.delete-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  color: #de350b;
+  display: flex;
+  align-items: center;
+}
+
+.delete-btn svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
 }
 
 .fab-btn {

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -28,6 +28,7 @@
         </button>
         <div class="tabs">
           <button class="tab-btn active" data-tab="general">一般</button>
+          <button class="tab-btn" data-tab="projects">プロジェクトキー</button>
           <button class="tab-btn" data-tab="about">About</button>
         </div>
       </div>
@@ -41,6 +42,16 @@
           </button>
           <button id="delete-host-btn" class="fab-btn secondary" title="削除" disabled>
             <svg viewBox="0 0 24 24"><path d="M19 13H5v-2h14v2z"/></svg>
+          </button>
+        </div>
+      </div>
+      <div class="tab-content hidden" id="projects-tab">
+        <div class="project-list-container">
+          <ul id="project-list"></ul>
+        </div>
+        <div class="project-actions">
+          <button id="add-project-btn" class="fab-btn" title="追加">
+            <svg viewBox="0 0 24 24"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
           </button>
         </div>
       </div>
@@ -58,6 +69,20 @@
             <li>Issues-Solo</li>
           </ul>
         </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="add-project-dialog" class="overlay hidden">
+    <div class="dialog">
+      <h3>プロジェクトキーの追加</h3>
+      <div class="input-field">
+        <label for="project-key-input">プロジェクトキー</label>
+        <input type="text" id="project-key-input" placeholder="例: PROJ">
+      </div>
+      <div class="dialog-actions">
+        <button id="cancel-add-project" class="text-btn">キャンセル</button>
+        <button id="confirm-add-project" class="text-btn">OK</button>
       </div>
     </div>
   </div>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -134,9 +134,14 @@ async function renderList() {
       const glyph = document.createElement('span');
       glyph.className = 'collapse-glyph';
       const isCollapsed = !!host.isCollapsed;
-      glyph.innerHTML = isCollapsed
-        ? '<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>' // 右向き
-        : '<svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>'; // 下向き
+
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('viewBox', '0 0 24 24');
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('d', isCollapsed ? 'M8 5v14l11-7z' : 'M7 10l5 5 5-5z');
+      svg.appendChild(path);
+      glyph.appendChild(svg);
+
       header.appendChild(glyph);
 
       header.addEventListener('click', async () => {
@@ -156,7 +161,12 @@ async function renderList() {
       let remainingIssues = [...hostIssues];
 
       projectSettings.forEach(proj => {
-        const projIssues = remainingIssues.filter(i => i.issueKey.startsWith(proj.key + '-'));
+        // プロジェクトキーが完全一致することを確認 (例: ABC-1 が ABCD のグループに入らないように)
+        const projIssues = remainingIssues.filter(i => {
+          const parts = i.issueKey.split('-');
+          return parts.length > 1 && parts[0] === proj.key;
+        });
+
         if (projIssues.length > 0) {
           remainingIssues = remainingIssues.filter(i => !projIssues.includes(i));
 
@@ -169,9 +179,14 @@ async function renderList() {
           const glyph = document.createElement('span');
           glyph.className = 'collapse-glyph';
           const isCollapsed = !!proj.isCollapsed;
-          glyph.innerHTML = isCollapsed
-            ? '<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>'
-            : '<svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>';
+
+          const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+          svg.setAttribute('viewBox', '0 0 24 24');
+          const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+          path.setAttribute('d', isCollapsed ? 'M8 5v14l11-7z' : 'M7 10l5 5 5-5z');
+          svg.appendChild(path);
+          glyph.appendChild(svg);
+
           projHeader.appendChild(glyph);
 
           const name = document.createElement('span');
@@ -325,7 +340,12 @@ async function renderProjectSettings() {
 
     const dragHandle = document.createElement('div');
     dragHandle.className = 'drag-handle';
-    dragHandle.innerHTML = '<svg viewBox="0 0 24 24"><path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>';
+    const dragSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    dragSvg.setAttribute('viewBox', '0 0 24 24');
+    const dragPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    dragPath.setAttribute('d', 'M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z');
+    dragSvg.appendChild(dragPath);
+    dragHandle.appendChild(dragSvg);
 
     const keyLabel = document.createElement('span');
     keyLabel.className = 'project-key-label';
@@ -348,7 +368,13 @@ async function renderProjectSettings() {
 
     const deleteBtn = document.createElement('button');
     deleteBtn.className = 'delete-btn';
-    deleteBtn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>';
+    const deleteSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    deleteSvg.setAttribute('viewBox', '0 0 24 24');
+    const deletePath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    deletePath.setAttribute('d', 'M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z');
+    deleteSvg.appendChild(deletePath);
+    deleteBtn.appendChild(deleteSvg);
+
     deleteBtn.addEventListener('click', async () => {
       const newSettings = settings.filter((_, i) => i !== index);
       await db.setProjectSettings(newSettings);

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -19,8 +19,25 @@ const deleteConfirmDialog = document.getElementById('delete-confirm-dialog');
 const cancelDeleteHostBtn = document.getElementById('cancel-delete-host');
 const confirmDeleteHostBtn = document.getElementById('confirm-delete-host');
 
+const projectList = document.getElementById('project-list');
+const addProjectBtn = document.getElementById('add-project-btn');
+const addProjectDialog = document.getElementById('add-project-dialog');
+const cancelAddProjectBtn = document.getElementById('cancel-add-project');
+const confirmAddProjectBtn = document.getElementById('confirm-add-project');
+const projectKeyInput = document.getElementById('project-key-input');
+
 let selectedHostIds = new Set();
 let currentSettings = [];
+let currentProjectSettings = [];
+
+const M3_COLORS = [
+  '#0061A4', // Blue
+  '#006D39', // Green
+  '#695F00', // Yellow
+  '#B3261E', // Red
+  '#6750A4', // Purple
+  '#006A60', // Teal
+];
 
 // 優先度のマッピングと色設定 (Material 3 パレット準拠)
 const PRIORITY_MAP = {
@@ -62,7 +79,9 @@ const STATUS_COLOR_MAP = {
 async function renderList() {
   const issues = await db.getAllIssues();
   const settings = await db.getSettings();
+  const projectSettings = await db.getProjectSettings();
   currentSettings = settings;
+  currentProjectSettings = projectSettings;
 
   if (issues.length === 0) {
     listElement.textContent = '';
@@ -133,9 +152,51 @@ async function renderList() {
     }
 
     if (!useAccordion || !host.isCollapsed) {
-      hostIssues.forEach(issue => {
-        const item = createIssueItem(issue);
-        listElement.appendChild(item);
+      // プロジェクトキー設定に従ってグルーピング
+      let remainingIssues = [...hostIssues];
+
+      projectSettings.forEach(proj => {
+        const projIssues = remainingIssues.filter(i => i.issueKey.startsWith(proj.key + '-'));
+        if (projIssues.length > 0) {
+          remainingIssues = remainingIssues.filter(i => !projIssues.includes(i));
+
+          const projHeader = document.createElement('div');
+          projHeader.className = 'project-group-header';
+          projHeader.style.backgroundColor = proj.color + '22'; // 薄く背景色をつける (alpha 22)
+          projHeader.style.color = proj.color;
+          projHeader.style.borderLeft = `4px solid ${proj.color}`;
+
+          const glyph = document.createElement('span');
+          glyph.className = 'collapse-glyph';
+          const isCollapsed = !!proj.isCollapsed;
+          glyph.innerHTML = isCollapsed
+            ? '<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>'
+            : '<svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>';
+          projHeader.appendChild(glyph);
+
+          const name = document.createElement('span');
+          name.textContent = proj.key;
+          projHeader.appendChild(name);
+
+          projHeader.addEventListener('click', async () => {
+            proj.isCollapsed = !proj.isCollapsed;
+            await db.setProjectSettings(projectSettings);
+            renderList();
+          });
+
+          listElement.appendChild(projHeader);
+
+          if (!isCollapsed) {
+            projIssues.forEach(issue => {
+              listElement.appendChild(createIssueItem(issue));
+            });
+          }
+        }
+      });
+
+      // 設定にないプロジェクトキーのIssue
+      remainingIssues.forEach(issue => {
+        listElement.appendChild(createIssueItem(issue));
       });
     }
   });
@@ -233,6 +294,7 @@ async function handleIssueClick(issue) {
 settingsBtn.addEventListener('click', () => {
   settingsPanel.classList.remove('hidden');
   renderHostSettings();
+  renderProjectSettings();
 });
 
 closeSettingsBtn.addEventListener('click', () => {
@@ -245,6 +307,124 @@ tabButtons.forEach(btn => {
     tabButtons.forEach(b => b.classList.toggle('active', b === btn));
     tabContents.forEach(c => c.classList.toggle('hidden', c.id !== `${tabName}-tab`));
   });
+});
+
+/**
+ * プロジェクト設定リストのレンダリング
+ */
+async function renderProjectSettings() {
+  const settings = await db.getProjectSettings();
+  currentProjectSettings = settings;
+  projectList.textContent = '';
+
+  settings.forEach((proj, index) => {
+    const li = document.createElement('li');
+    li.className = 'project-item';
+    li.dataset.key = proj.key;
+    li.draggable = true;
+
+    const dragHandle = document.createElement('div');
+    dragHandle.className = 'drag-handle';
+    dragHandle.innerHTML = '<svg viewBox="0 0 24 24"><path d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>';
+
+    const keyLabel = document.createElement('span');
+    keyLabel.className = 'project-key-label';
+    keyLabel.textContent = proj.key;
+
+    const colorPicker = document.createElement('div');
+    colorPicker.className = 'color-picker';
+    M3_COLORS.forEach(color => {
+      const option = document.createElement('div');
+      option.className = `color-option ${proj.color === color ? 'selected' : ''}`;
+      option.style.backgroundColor = color;
+      option.addEventListener('click', async () => {
+        proj.color = color;
+        await db.setProjectSettings(settings);
+        renderProjectSettings();
+        renderList();
+      });
+      colorPicker.appendChild(option);
+    });
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'delete-btn';
+    deleteBtn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>';
+    deleteBtn.addEventListener('click', async () => {
+      const newSettings = settings.filter((_, i) => i !== index);
+      await db.setProjectSettings(newSettings);
+      renderProjectSettings();
+      renderList();
+    });
+
+    li.appendChild(dragHandle);
+    li.appendChild(keyLabel);
+    li.appendChild(colorPicker);
+    li.appendChild(deleteBtn);
+
+    // ドラッグ＆ドロップ
+    li.addEventListener('dragstart', (e) => {
+      li.classList.add('dragging');
+      e.dataTransfer.setData('text/plain', index);
+    });
+
+    li.addEventListener('dragend', () => {
+      li.classList.remove('dragging');
+    });
+
+    projectList.appendChild(li);
+  });
+}
+
+// プロジェクトリストのドラッグ＆ドロップ
+projectList.addEventListener('dragover', (e) => {
+  e.preventDefault();
+  const draggingItem = document.querySelector('.project-item.dragging');
+  if (!draggingItem) return;
+
+  const siblings = [...projectList.querySelectorAll('.project-item:not(.dragging)')];
+  const nextSibling = siblings.find(sibling => {
+    return e.clientY <= sibling.offsetTop + sibling.offsetHeight / 2;
+  });
+  projectList.insertBefore(draggingItem, nextSibling);
+});
+
+projectList.addEventListener('drop', async (e) => {
+  e.preventDefault();
+  const newSettings = [...projectList.querySelectorAll('.project-item')].map(item => {
+    return currentProjectSettings.find(p => p.key === item.dataset.key);
+  });
+  await db.setProjectSettings(newSettings);
+  currentProjectSettings = newSettings;
+  renderList();
+});
+
+// プロジェクト追加
+addProjectBtn.addEventListener('click', () => {
+  addProjectDialog.classList.remove('hidden');
+  projectKeyInput.value = '';
+  projectKeyInput.focus();
+});
+
+cancelAddProjectBtn.addEventListener('click', () => {
+  addProjectDialog.classList.add('hidden');
+});
+
+confirmAddProjectBtn.addEventListener('click', async () => {
+  const key = projectKeyInput.value.trim().toUpperCase();
+  if (key) {
+    const settings = await db.getProjectSettings();
+    if (!settings.some(p => p.key === key)) {
+      settings.push({
+        key,
+        color: M3_COLORS[0],
+        isCollapsed: false
+      });
+      await db.setProjectSettings(settings);
+    }
+    addProjectDialog.classList.add('hidden');
+    renderProjectSettings();
+    renderList();
+  }
 });
 
 /**


### PR DESCRIPTION
プロジェクトキーごとに表示順序とラベル色を設定できる機能を追加しました。

主な変更点：
1. **db.js**: `chrome.storage.local`を使用したプロジェクト設定の取得・保存メソッドを追加。
2. **sidepanel.html**: 設定パネルに「プロジェクトキー」タブを追加し、追加用ダイアログとリスト構造を定義。
3. **sidepanel.css**: 
   - 3.5行分の固定高を持つスクロール可能なプロジェクトリストのスタイル。
   - Material 3準拠のカラーパレット。
   - Jiraを彷彿とさせる青色（#0061A4）を適用したホストヘッダー。
4. **sidepanel.js**:
   - プロジェクト設定のレンダリング、追加、削除、ドラッグ＆ドロップによる並べ替えロジック。
   - `renderList`を更新し、ホスト -> 設定されたプロジェクトキー -> その他の順で課題をグルーピングして表示。
   - プロジェクトごとのアコーディオン開閉状態の永続化。

これにより、複数のプロジェクトが混在する環境でも、特定のプロジェクトを優先的に、かつ視覚的に区別して管理できるようになります。

---
*PR created automatically by Jules for task [3847048258484654233](https://jules.google.com/task/3847048258484654233) started by @masanori-satake*