### PR TITLE
設定画面の拡張と履歴管理機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.8.0-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.9.0-blue)](manifest.json)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/build.py"

--- a/projects/app/db.js
+++ b/projects/app/db.js
@@ -302,7 +302,9 @@ export class IssuesDB {
         const newProjectSettings = [...currentProjectSettings];
         if (data.projectSettings) {
           for (const ps of data.projectSettings) {
-            if (!newProjectSettings.some((existing) => existing.key === ps.key)) {
+            if (
+              !newProjectSettings.some((existing) => existing.key === ps.key)
+            ) {
               newProjectSettings.push(ps);
             }
           }

--- a/projects/app/db.js
+++ b/projects/app/db.js
@@ -315,7 +315,9 @@ export class IssuesDB {
         const newProjectSettings = [...currentProjectSettings];
         if (data.projectSettings) {
           for (const ps of data.projectSettings) {
-            if (!newProjectSettings.some((existing) => existing.key === ps.key)) {
+            if (
+              !newProjectSettings.some((existing) => existing.key === ps.key)
+            ) {
               newProjectSettings.push(ps);
             }
           }

--- a/projects/app/db.js
+++ b/projects/app/db.js
@@ -36,19 +36,53 @@ export class IssuesDB {
 
   async upsertIssue(issue) {
     const db = await this.open();
+    const maxCount = await this.getMaxHistoryCount();
+
     return new Promise((resolve, reject) => {
       const transaction = db.transaction([this.storeName], "readwrite");
       const store = transaction.objectStore(this.storeName);
 
       const getRequest = store.get(issue.url);
-      getRequest.onsuccess = () => {
+      getRequest.onsuccess = async () => {
         const existing = getRequest.result || {};
         const updated = { ...existing, ...issue, lastAccessed: Date.now() };
         const putRequest = store.put(updated);
-        putRequest.onsuccess = () => resolve();
+
+        putRequest.onsuccess = async () => {
+          // 履歴上限チェック
+          const countRequest = store.count();
+          countRequest.onsuccess = async () => {
+            if (countRequest.result > maxCount) {
+              const allIssues = await this.getAllIssues();
+              const toDelete = allIssues.slice(maxCount);
+              const deleteTransaction = db.transaction(
+                [this.storeName],
+                "readwrite",
+              );
+              const deleteStore = deleteTransaction.objectStore(this.storeName);
+              for (const item of toDelete) {
+                deleteStore.delete(item.url);
+              }
+              deleteTransaction.oncomplete = () => resolve();
+            } else {
+              resolve();
+            }
+          };
+        };
         putRequest.onerror = () => reject(putRequest.error);
       };
       getRequest.onerror = () => reject(getRequest.error);
+    });
+  }
+
+  async clearAllIssues() {
+    const db = await this.open();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([this.storeName], "readwrite");
+      const store = transaction.objectStore(this.storeName);
+      const request = store.clear();
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
     });
   }
 
@@ -173,5 +207,132 @@ export class IssuesDB {
         resolve();
       });
     });
+  }
+
+  async getMaxHistoryCount() {
+    return new Promise((resolve) => {
+      chrome.storage.local.get(["maxHistoryCount"], (result) => {
+        resolve(result.maxHistoryCount || 50);
+      });
+    });
+  }
+
+  async setMaxHistoryCount(maxHistoryCount) {
+    return new Promise((resolve) => {
+      chrome.storage.local.set({ maxHistoryCount }, () => {
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * 履歴データのインポート
+   */
+  async importIssues(ndjsonText, mode = "add") {
+    const lines = ndjsonText.trim().split("\n");
+    const issues = lines
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch (e) {
+          return null;
+        }
+      })
+      .filter((i) => i && i.url);
+
+    if (mode === "overwrite") {
+      await this.clearAllIssues();
+    }
+
+    // 重複を考慮しつつインポート（overwriteなら全件、addなら既存を優先するか上書きするか）
+    // ここでは単純に upsertIssue を使う（最新の visitation 情報が保持されるため）
+    // ただし、一括処理の方が効率的なので transaction を手動で制御する
+    const db = await this.open();
+    const maxCount = await this.getMaxHistoryCount();
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([this.storeName], "readwrite");
+      const store = transaction.objectStore(this.storeName);
+
+      for (const issue of issues) {
+        store.put(issue);
+      }
+
+      transaction.oncomplete = async () => {
+        // インポート後の上限チェック
+        const allIssues = await this.getAllIssues();
+        if (allIssues.length > maxCount) {
+          const toDelete = allIssues.slice(maxCount);
+          const deleteTransaction = db.transaction(
+            [this.storeName],
+            "readwrite",
+          );
+          const deleteStore = deleteTransaction.objectStore(this.storeName);
+          for (const item of toDelete) {
+            deleteStore.delete(item.url);
+          }
+          deleteTransaction.oncomplete = () => resolve();
+        } else {
+          resolve();
+        }
+      };
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  /**
+   * 設定データのインポート
+   */
+  async importSettings(jsonText, mode = "add") {
+    try {
+      const data = JSON.parse(jsonText);
+      if (mode === "overwrite") {
+        const toSet = {};
+        if (data.settings) toSet.settings = data.settings;
+        if (data.projectSettings) toSet.projectSettings = data.projectSettings;
+        if (data.otherCollapsed !== undefined)
+          toSet.otherCollapsed = data.otherCollapsed;
+        if (data.maxHistoryCount !== undefined)
+          toSet.maxHistoryCount = data.maxHistoryCount;
+
+        return new Promise((resolve) => {
+          chrome.storage.local.set(toSet, () => resolve());
+        });
+      } else {
+        // 追加モード
+        const currentSettings = await this.getSettings();
+        const currentProjectSettings = await this.getProjectSettings();
+
+        const newSettings = [...currentSettings];
+        if (data.settings) {
+          for (const s of data.settings) {
+            if (!newSettings.some((existing) => existing.url === s.url)) {
+              newSettings.push(s);
+            }
+          }
+        }
+
+        const newProjectSettings = [...currentProjectSettings];
+        if (data.projectSettings) {
+          for (const ps of data.projectSettings) {
+            if (!newProjectSettings.some((existing) => existing.key === ps.key)) {
+              newProjectSettings.push(ps);
+            }
+          }
+        }
+
+        const toSet = {
+          settings: newSettings,
+          projectSettings: newProjectSettings,
+        };
+        // booleanや数値は上書きせざるを得ないが、addモードなら現在の値を優先
+        return new Promise((resolve) => {
+          chrome.storage.local.set(toSet, () => resolve());
+        });
+      }
+    } catch (e) {
+      console.error("Import failed", e);
+      throw e;
+    }
   }
 }

--- a/projects/app/db.js
+++ b/projects/app/db.js
@@ -43,35 +43,28 @@ export class IssuesDB {
       const store = transaction.objectStore(this.storeName);
 
       const getRequest = store.get(issue.url);
-      getRequest.onsuccess = async () => {
+      getRequest.onsuccess = () => {
         const existing = getRequest.result || {};
         const updated = { ...existing, ...issue, lastAccessed: Date.now() };
-        const putRequest = store.put(updated);
+        store.put(updated);
 
-        putRequest.onsuccess = async () => {
-          // 履歴上限チェック
-          const countRequest = store.count();
-          countRequest.onsuccess = async () => {
-            if (countRequest.result > maxCount) {
-              const allIssues = await this.getAllIssues();
-              const toDelete = allIssues.slice(maxCount);
-              const deleteTransaction = db.transaction(
-                [this.storeName],
-                "readwrite",
-              );
-              const deleteStore = deleteTransaction.objectStore(this.storeName);
-              for (const item of toDelete) {
-                deleteStore.delete(item.url);
-              }
-              deleteTransaction.oncomplete = () => resolve();
-            } else {
-              resolve();
+        // 同一トランザクション内で上限チェックを行う
+        const getAllRequest = store.getAll();
+        getAllRequest.onsuccess = () => {
+          const allIssues = getAllRequest.result.sort(
+            (a, b) => b.lastAccessed - a.lastAccessed,
+          );
+          if (allIssues.length > maxCount) {
+            const toDelete = allIssues.slice(maxCount);
+            for (const item of toDelete) {
+              store.delete(item.url);
             }
-          };
+          }
         };
-        putRequest.onerror = () => reject(putRequest.error);
       };
-      getRequest.onerror = () => reject(getRequest.error);
+
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
     });
   }
 
@@ -240,13 +233,6 @@ export class IssuesDB {
       })
       .filter((i) => i && i.url);
 
-    if (mode === "overwrite") {
-      await this.clearAllIssues();
-    }
-
-    // 重複を考慮しつつインポート（overwriteなら全件、addなら既存を優先するか上書きするか）
-    // ここでは単純に upsertIssue を使う（最新の visitation 情報が保持されるため）
-    // ただし、一括処理の方が効率的なので transaction を手動で制御する
     const db = await this.open();
     const maxCount = await this.getMaxHistoryCount();
 
@@ -254,28 +240,29 @@ export class IssuesDB {
       const transaction = db.transaction([this.storeName], "readwrite");
       const store = transaction.objectStore(this.storeName);
 
+      if (mode === "overwrite") {
+        store.clear();
+      }
+
       for (const issue of issues) {
         store.put(issue);
       }
 
-      transaction.oncomplete = async () => {
-        // インポート後の上限チェック
-        const allIssues = await this.getAllIssues();
+      // インポート後の上限チェックも同一トランザクション内で行う
+      const getAllRequest = store.getAll();
+      getAllRequest.onsuccess = () => {
+        const allIssues = getAllRequest.result.sort(
+          (a, b) => b.lastAccessed - a.lastAccessed,
+        );
         if (allIssues.length > maxCount) {
           const toDelete = allIssues.slice(maxCount);
-          const deleteTransaction = db.transaction(
-            [this.storeName],
-            "readwrite",
-          );
-          const deleteStore = deleteTransaction.objectStore(this.storeName);
           for (const item of toDelete) {
-            deleteStore.delete(item.url);
+            store.delete(item.url);
           }
-          deleteTransaction.oncomplete = () => resolve();
-        } else {
-          resolve();
         }
       };
+
+      transaction.oncomplete = () => resolve();
       transaction.onerror = () => reject(transaction.error);
     });
   }
@@ -315,9 +302,7 @@ export class IssuesDB {
         const newProjectSettings = [...currentProjectSettings];
         if (data.projectSettings) {
           for (const ps of data.projectSettings) {
-            if (
-              !newProjectSettings.some((existing) => existing.key === ps.key)
-            ) {
+            if (!newProjectSettings.some((existing) => existing.key === ps.key)) {
               newProjectSettings.push(ps);
             }
           }

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Issues-Solo",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "permissions": [
     "sidePanel",

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -307,6 +307,85 @@ header {
   padding: 16px;
 }
 
+.section-title {
+  margin: 0 0 12px 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: #0052cc;
+  border-bottom: 1px solid #eef0f2;
+  padding-bottom: 4px;
+}
+
+section {
+  margin-bottom: 24px;
+}
+
+section:last-child {
+  margin-bottom: 0;
+}
+
+.settings-item {
+  margin-bottom: 16px;
+}
+
+.settings-item label {
+  display: block;
+  font-size: 13px;
+  margin-bottom: 8px;
+}
+
+.settings-item input[type="range"] {
+  width: 100%;
+  margin: 0;
+}
+
+.range-labels {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 4px;
+  margin-top: -4px;
+}
+
+.range-labels span {
+  font-size: 10px;
+  color: var(--secondary-text);
+}
+
+.settings-actions-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.text-btn.small {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+
+.import-mode-selector {
+  margin-bottom: 12px;
+}
+
+.import-mode-selector label {
+  font-size: 12px;
+  color: var(--secondary-text);
+}
+
+.radio-group {
+  display: flex;
+  gap: 16px;
+  margin-top: 4px;
+}
+
+.radio-group label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--text-color);
+}
+
 /* Host List */
 .host-list-container {
   height: calc(48px * 3.5);

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -60,28 +60,67 @@
           </button>
         </div>
         <div class="tab-content" id="general-tab">
-          <div class="host-list-container">
-            <ul id="host-list"></ul>
-          </div>
-          <div class="host-actions">
-            <button id="add-host-btn" class="fab-btn" title="追加">
-              <svg viewBox="0 0 24 24">
-                <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
-              </svg>
-            </button>
-          </div>
+          <section>
+            <h4 class="section-title">Jira サイト</h4>
+            <div class="host-list-container">
+              <ul id="host-list"></ul>
+            </div>
+            <div class="host-actions">
+              <button id="add-host-btn" class="fab-btn" title="追加">
+                <svg viewBox="0 0 24 24">
+                  <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                </svg>
+              </button>
+            </div>
+          </section>
+
+          <section>
+            <h4 class="section-title">履歴</h4>
+            <div class="settings-item">
+              <label for="max-history-range">最大保持件数: <span id="max-history-value">50</span></label>
+              <input type="range" id="max-history-range" min="0" max="2" step="1" value="1">
+              <div class="range-labels">
+                <span>20</span>
+                <span>50</span>
+                <span>100</span>
+              </div>
+            </div>
+            <div class="settings-actions-row">
+              <button id="export-history-btn" class="text-btn small">エクスポート</button>
+              <button id="import-history-btn" class="text-btn small">インポート</button>
+              <button id="clear-history-btn" class="text-btn small danger">全削除</button>
+            </div>
+          </section>
+
+          <section>
+            <h4 class="section-title">データ</h4>
+            <div class="import-mode-selector">
+              <label>インポート時の動作:</label>
+              <div class="radio-group">
+                <label><input type="radio" name="import-mode" value="add" checked> 追加</label>
+                <label><input type="radio" name="import-mode" value="overwrite"> 上書き</label>
+              </div>
+            </div>
+            <div class="settings-actions-row">
+              <button id="export-settings-btn" class="text-btn">エクスポート</button>
+              <button id="import-settings-btn" class="text-btn">インポート</button>
+            </div>
+          </section>
         </div>
         <div class="tab-content hidden" id="projects-tab">
-          <div class="project-list-container">
-            <ul id="project-list"></ul>
-          </div>
-          <div class="project-actions">
-            <button id="add-project-btn" class="fab-btn" title="追加">
-              <svg viewBox="0 0 24 24">
-                <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
-              </svg>
-            </button>
-          </div>
+          <section>
+            <h4 class="section-title">プロジェクト</h4>
+            <div class="project-list-container">
+              <ul id="project-list"></ul>
+            </div>
+            <div class="project-actions">
+              <button id="add-project-btn" class="fab-btn" title="追加">
+                <svg viewBox="0 0 24 24">
+                  <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                </svg>
+              </button>
+            </div>
+          </section>
         </div>
         <div class="tab-content hidden" id="about-tab">
           <div class="about-container">
@@ -93,6 +132,17 @@
               この拡張機能は、プライバシーを最優先に設計されています。すべてのデータはあなたのブラウザ内にのみ保存され、外部サーバーに送信されることはありません。
             </p>
           </div>
+        </div>
+      </div>
+    </div>
+
+    <div id="confirm-dialog" class="overlay hidden">
+      <div class="dialog">
+        <h3 id="confirm-title">確認</h3>
+        <p id="confirm-message"></p>
+        <div class="dialog-actions">
+          <button id="confirm-cancel" class="text-btn">キャンセル</button>
+          <button id="confirm-ok" class="text-btn danger">OK</button>
         </div>
       </div>
     </div>

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -77,8 +77,17 @@
           <section>
             <h4 class="section-title">履歴</h4>
             <div class="settings-item">
-              <label for="max-history-range">最大保持件数: <span id="max-history-value">50</span></label>
-              <input type="range" id="max-history-range" min="0" max="2" step="1" value="1">
+              <label for="max-history-range"
+                >最大保持件数: <span id="max-history-value">50</span></label
+              >
+              <input
+                type="range"
+                id="max-history-range"
+                min="0"
+                max="2"
+                step="1"
+                value="1"
+              />
               <div class="range-labels">
                 <span>20</span>
                 <span>50</span>
@@ -86,9 +95,15 @@
               </div>
             </div>
             <div class="settings-actions-row">
-              <button id="export-history-btn" class="text-btn small">エクスポート</button>
-              <button id="import-history-btn" class="text-btn small">インポート</button>
-              <button id="clear-history-btn" class="text-btn small danger">全削除</button>
+              <button id="export-history-btn" class="text-btn small">
+                エクスポート
+              </button>
+              <button id="import-history-btn" class="text-btn small">
+                インポート
+              </button>
+              <button id="clear-history-btn" class="text-btn small danger">
+                全削除
+              </button>
             </div>
           </section>
 
@@ -97,13 +112,23 @@
             <div class="import-mode-selector">
               <label>インポート時の動作:</label>
               <div class="radio-group">
-                <label><input type="radio" name="import-mode" value="add" checked> 追加</label>
-                <label><input type="radio" name="import-mode" value="overwrite"> 上書き</label>
+                <label
+                  ><input type="radio" name="import-mode" value="add" checked />
+                  追加</label
+                >
+                <label
+                  ><input type="radio" name="import-mode" value="overwrite" />
+                  上書き</label
+                >
               </div>
             </div>
             <div class="settings-actions-row">
-              <button id="export-settings-btn" class="text-btn">エクスポート</button>
-              <button id="import-settings-btn" class="text-btn">インポート</button>
+              <button id="export-settings-btn" class="text-btn">
+                エクスポート
+              </button>
+              <button id="import-settings-btn" class="text-btn">
+                インポート
+              </button>
             </div>
           </section>
         </div>

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -77,17 +77,8 @@
           <section>
             <h4 class="section-title">履歴</h4>
             <div class="settings-item">
-              <label for="max-history-range"
-                >最大保持件数: <span id="max-history-value">50</span></label
-              >
-              <input
-                type="range"
-                id="max-history-range"
-                min="0"
-                max="2"
-                step="1"
-                value="1"
-              />
+              <label for="max-history-range">最大保持件数: <span id="max-history-value">50</span></label>
+              <input type="range" id="max-history-range" min="0" max="2" step="1" value="1">
               <div class="range-labels">
                 <span>20</span>
                 <span>50</span>
@@ -95,15 +86,9 @@
               </div>
             </div>
             <div class="settings-actions-row">
-              <button id="export-history-btn" class="text-btn small">
-                エクスポート
-              </button>
-              <button id="import-history-btn" class="text-btn small">
-                インポート
-              </button>
-              <button id="clear-history-btn" class="text-btn small danger">
-                全削除
-              </button>
+              <button id="export-history-btn" class="text-btn small">エクスポート</button>
+              <button id="import-history-btn" class="text-btn small">インポート</button>
+              <button id="clear-history-btn" class="text-btn small danger">全削除</button>
             </div>
           </section>
 
@@ -112,23 +97,13 @@
             <div class="import-mode-selector">
               <label>インポート時の動作:</label>
               <div class="radio-group">
-                <label
-                  ><input type="radio" name="import-mode" value="add" checked />
-                  追加</label
-                >
-                <label
-                  ><input type="radio" name="import-mode" value="overwrite" />
-                  上書き</label
-                >
+                <label><input type="radio" name="import-mode" value="add" checked> 追加</label>
+                <label><input type="radio" name="import-mode" value="overwrite"> 上書き</label>
               </div>
             </div>
             <div class="settings-actions-row">
-              <button id="export-settings-btn" class="text-btn">
-                エクスポート
-              </button>
-              <button id="import-settings-btn" class="text-btn">
-                インポート
-              </button>
+              <button id="export-settings-btn" class="text-btn">エクスポート</button>
+              <button id="import-settings-btn" class="text-btn">インポート</button>
             </div>
           </section>
         </div>

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -464,13 +464,17 @@ exportHistoryBtn.addEventListener("click", async () => {
 importHistoryBtn.addEventListener("click", async () => {
   try {
     const text = await navigator.clipboard.readText();
-    const mode = document.querySelector('input[name="import-mode"]:checked').value;
+    const mode = document.querySelector(
+      'input[name="import-mode"]:checked',
+    ).value;
     await db.importIssues(text, mode);
     renderList();
     alert("履歴データをインポートしました");
   } catch (err) {
     console.error("Failed to import history", err);
-    alert("インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。");
+    alert(
+      "インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。",
+    );
   }
 });
 
@@ -500,7 +504,9 @@ exportSettingsBtn.addEventListener("click", async () => {
 importSettingsBtn.addEventListener("click", async () => {
   try {
     const text = await navigator.clipboard.readText();
-    const mode = document.querySelector('input[name="import-mode"]:checked').value;
+    const mode = document.querySelector(
+      'input[name="import-mode"]:checked',
+    ).value;
     await db.importSettings(text, mode);
     renderList();
     renderHostSettings();
@@ -510,7 +516,9 @@ importSettingsBtn.addEventListener("click", async () => {
     alert("設定データをインポートしました");
   } catch (err) {
     console.error("Failed to import settings", err);
-    alert("インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。");
+    alert(
+      "インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。",
+    );
   }
 });
 

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -464,17 +464,23 @@ exportHistoryBtn.addEventListener("click", async () => {
 importHistoryBtn.addEventListener("click", async () => {
   try {
     if (!navigator.clipboard || !navigator.clipboard.readText) {
-      alert("このブラウザではクリップボードからの読み取りがサポートされていないか、許可されていません。");
+      alert(
+        "このブラウザではクリップボードからの読み取りがサポートされていないか、許可されていません。",
+      );
       return;
     }
     const text = await navigator.clipboard.readText();
-    const mode = document.querySelector('input[name="import-mode"]:checked').value;
+    const mode = document.querySelector(
+      'input[name="import-mode"]:checked',
+    ).value;
     await db.importIssues(text, mode);
     renderList();
     alert("履歴データをインポートしました");
   } catch (err) {
     console.error("Failed to import history", err);
-    alert("インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。");
+    alert(
+      "インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。",
+    );
   }
 });
 
@@ -504,11 +510,15 @@ exportSettingsBtn.addEventListener("click", async () => {
 importSettingsBtn.addEventListener("click", async () => {
   try {
     if (!navigator.clipboard || !navigator.clipboard.readText) {
-      alert("このブラウザではクリップボードからの読み取りがサポートされていないか、許可されていません。");
+      alert(
+        "このブラウザではクリップボードからの読み取りがサポートされていないか、許可されていません。",
+      );
       return;
     }
     const text = await navigator.clipboard.readText();
-    const mode = document.querySelector('input[name="import-mode"]:checked').value;
+    const mode = document.querySelector(
+      'input[name="import-mode"]:checked',
+    ).value;
     await db.importSettings(text, mode);
     renderList();
     renderHostSettings();
@@ -518,7 +528,9 @@ importSettingsBtn.addEventListener("click", async () => {
     alert("設定データをインポートしました");
   } catch (err) {
     console.error("Failed to import settings", err);
-    alert("インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。");
+    alert(
+      "インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。",
+    );
   }
 });
 

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -20,6 +20,18 @@ const addProjectDialog = document.getElementById("add-project-dialog");
 const cancelAddProjectBtn = document.getElementById("cancel-add-project");
 const confirmAddProjectBtn = document.getElementById("confirm-add-project");
 const projectKeyInput = document.getElementById("project-key-input");
+const maxHistoryRange = document.getElementById("max-history-range");
+const maxHistoryValue = document.getElementById("max-history-value");
+const exportHistoryBtn = document.getElementById("export-history-btn");
+const importHistoryBtn = document.getElementById("import-history-btn");
+const clearHistoryBtn = document.getElementById("clear-history-btn");
+const exportSettingsBtn = document.getElementById("export-settings-btn");
+const importSettingsBtn = document.getElementById("import-settings-btn");
+const confirmDialog = document.getElementById("confirm-dialog");
+const confirmTitle = document.getElementById("confirm-title");
+const confirmMessage = document.getElementById("confirm-message");
+const confirmOkBtn = document.getElementById("confirm-ok");
+const confirmCancelBtn = document.getElementById("confirm-cancel");
 
 let currentSettings = [];
 let currentProjectSettings = [];
@@ -374,14 +386,132 @@ async function handleIssueClick(issue) {
 }
 
 // 設定画面の制御ロジック
-settingsBtn.addEventListener("click", () => {
+settingsBtn.addEventListener("click", async () => {
   settingsPanel.classList.remove("hidden");
   renderHostSettings();
   renderProjectSettings();
+  const maxCount = await db.getMaxHistoryCount();
+  updateMaxHistoryUI(maxCount);
 });
 
 closeSettingsBtn.addEventListener("click", () => {
   settingsPanel.classList.add("hidden");
+});
+
+function updateMaxHistoryUI(count) {
+  maxHistoryValue.textContent = count;
+  const index = [20, 50, 100].indexOf(count);
+  if (index !== -1) {
+    maxHistoryRange.value = index;
+  }
+}
+
+maxHistoryRange.addEventListener("input", async () => {
+  const counts = [20, 50, 100];
+  const count = counts[maxHistoryRange.value];
+  maxHistoryValue.textContent = count;
+  await db.setMaxHistoryCount(count);
+});
+
+/**
+ * カスタム確認ダイアログ
+ */
+function showConfirm(title, message, onOk) {
+  confirmTitle.textContent = title;
+  confirmMessage.textContent = message;
+  confirmDialog.classList.remove("hidden");
+
+  const cleanup = () => {
+    confirmDialog.classList.add("hidden");
+    confirmOkBtn.removeEventListener("click", handleOk);
+    confirmCancelBtn.removeEventListener("click", cleanup);
+  };
+
+  const handleOk = () => {
+    onOk();
+    cleanup();
+  };
+
+  confirmOkBtn.addEventListener("click", handleOk);
+  confirmCancelBtn.addEventListener("click", cleanup);
+}
+
+// 履歴の全削除
+clearHistoryBtn.addEventListener("click", () => {
+  showConfirm(
+    "履歴の全削除",
+    "現在保持されているすべての履歴エントリーを削除します。よろしいですか？",
+    async () => {
+      await db.clearAllIssues();
+      renderList();
+    },
+  );
+});
+
+// 履歴のエクスポート (NDJSON)
+exportHistoryBtn.addEventListener("click", async () => {
+  const issues = await db.getAllIssues();
+  const ndjson = issues.map((i) => JSON.stringify(i)).join("\n");
+  try {
+    await navigator.clipboard.writeText(ndjson);
+    alert("履歴データをクリップボードにコピーしました (NDJSON形式)");
+  } catch (err) {
+    console.error("Failed to copy history", err);
+  }
+});
+
+// 履歴のインポート
+importHistoryBtn.addEventListener("click", async () => {
+  try {
+    const text = await navigator.clipboard.readText();
+    const mode = document.querySelector('input[name="import-mode"]:checked').value;
+    await db.importIssues(text, mode);
+    renderList();
+    alert("履歴データをインポートしました");
+  } catch (err) {
+    console.error("Failed to import history", err);
+    alert("インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。");
+  }
+});
+
+// 設定のエクスポート (JSON)
+exportSettingsBtn.addEventListener("click", async () => {
+  const settings = await db.getSettings();
+  const projectSettings = await db.getProjectSettings();
+  const otherCollapsed = await db.getOtherCollapsed();
+  const maxHistoryCount = await db.getMaxHistoryCount();
+
+  const data = {
+    settings,
+    projectSettings,
+    otherCollapsed,
+    maxHistoryCount,
+  };
+
+  try {
+    await navigator.clipboard.writeText(JSON.stringify(data, null, 2));
+    alert("設定データをクリップボードにコピーしました (JSON形式)");
+  } catch (err) {
+    console.error("Failed to copy settings", err);
+  }
+});
+
+// 設定のインポート
+importSettingsBtn.addEventListener("click", async () => {
+  try {
+    const text = await navigator.clipboard.readText();
+    const mode = document.querySelector('input[name="import-mode"]:checked').value;
+    await db.importSettings(text, mode);
+    renderList();
+    renderHostSettings();
+    renderProjectSettings();
+    const maxCount = await db.getMaxHistoryCount();
+    updateMaxHistoryUI(maxCount);
+    alert("設定データをインポートしました");
+  } catch (err) {
+    console.error("Failed to import settings", err);
+    alert("インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。");
+  }
 });
 
 tabButtons.forEach((btn) => {

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -463,18 +463,18 @@ exportHistoryBtn.addEventListener("click", async () => {
 // 履歴のインポート
 importHistoryBtn.addEventListener("click", async () => {
   try {
+    if (!navigator.clipboard || !navigator.clipboard.readText) {
+      alert("このブラウザではクリップボードからの読み取りがサポートされていないか、許可されていません。");
+      return;
+    }
     const text = await navigator.clipboard.readText();
-    const mode = document.querySelector(
-      'input[name="import-mode"]:checked',
-    ).value;
+    const mode = document.querySelector('input[name="import-mode"]:checked').value;
     await db.importIssues(text, mode);
     renderList();
     alert("履歴データをインポートしました");
   } catch (err) {
     console.error("Failed to import history", err);
-    alert(
-      "インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。",
-    );
+    alert("インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。");
   }
 });
 
@@ -503,10 +503,12 @@ exportSettingsBtn.addEventListener("click", async () => {
 // 設定のインポート
 importSettingsBtn.addEventListener("click", async () => {
   try {
+    if (!navigator.clipboard || !navigator.clipboard.readText) {
+      alert("このブラウザではクリップボードからの読み取りがサポートされていないか、許可されていません。");
+      return;
+    }
     const text = await navigator.clipboard.readText();
-    const mode = document.querySelector(
-      'input[name="import-mode"]:checked',
-    ).value;
+    const mode = document.querySelector('input[name="import-mode"]:checked').value;
     await db.importSettings(text, mode);
     renderList();
     renderHostSettings();
@@ -516,9 +518,7 @@ importSettingsBtn.addEventListener("click", async () => {
     alert("設定データをインポートしました");
   } catch (err) {
     console.error("Failed to import settings", err);
-    alert(
-      "インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。",
-    );
+    alert("インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。");
   }
 });
 


### PR DESCRIPTION
設定画面の使い勝手向上とデータ管理機能の強化を行いました。
主な変更点：
1. UI改善：セクションタイトル（Jira サイト、履歴、データ、プロジェクト）を追加し、設定項目を整理しました。
2. 履歴管理：ストレージを圧迫しないよう、履歴の最大保持件数を20, 50, 100件から選択可能にし、上限を超えた場合は古いものから自動削除されるようにしました。また、履歴をワンクリックで全削除できるボタン（確認ダイアログ付き）を実装しました。
3. データ移行：他のブラウザ（Edge等）への移行を容易にするため、設定データと履歴データを個別にエクスポート/インポートできるようにしました。セキュリティと簡便性のバランスを考慮し、クリップボード経由でのデータ授受を行います。インポート時は「追加」または「上書き」を選択可能です。
4. バージョン更新：機能追加に伴い、システム全体のバージョンを0.9.0に更新しました。

---
*PR created automatically by Jules for task [17562463057018891239](https://jules.google.com/task/17562463057018891239) started by @masanori-satake*