### PR TITLE
Issueリストのソート機能追加とUI改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.9.1-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.10.0-blue)](manifest.json)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/build.py"

--- a/projects/app/db.js
+++ b/projects/app/db.js
@@ -237,6 +237,24 @@ export class IssuesDB {
     });
   }
 
+  async getSortSettings() {
+    return new Promise((resolve) => {
+      chrome.storage.local.get(["sortSettings"], (result) => {
+        resolve(
+          result.sortSettings || { type: "lastAccessed", direction: "desc" },
+        );
+      });
+    });
+  }
+
+  async setSortSettings(sortSettings) {
+    return new Promise((resolve) => {
+      chrome.storage.local.set({ sortSettings }, () => {
+        resolve();
+      });
+    });
+  }
+
   /**
    * 履歴の件数を制限数に収まるよう削除する
    */

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Issues-Solo",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "permissions": [
     "sidePanel",

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -59,6 +59,42 @@ header {
   height: 32px;
 }
 
+.sort-button-group {
+  display: flex;
+  background-color: rgba(0, 0, 0, 0.05);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.sort-btn {
+  background: none;
+  border: none;
+  display: flex;
+  align-items: center;
+  padding: 4px 6px;
+  cursor: pointer;
+  color: var(--secondary-text);
+  transition: all 0.2s;
+  gap: 2px;
+}
+
+.sort-btn:hover {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.sort-btn.active {
+  background-color: #d1e4ff;
+  color: #001d36;
+}
+
+.sort-btn .type-icon {
+  font-size: 18px;
+}
+
+.sort-btn .dir-icon {
+  font-size: 14px;
+}
+
 .spacer {
   flex-grow: 1;
 }

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -8,6 +8,42 @@
   <body>
     <header>
       <div class="header-content">
+        <div class="sort-button-group">
+          <button
+            id="sort-lastAccessed"
+            class="sort-btn"
+            title="最終表示時刻順"
+          >
+            <span class="material-symbols-outlined type-icon">schedule</span>
+            <span class="material-symbols-outlined dir-icon"
+              >arrow_downward</span
+            >
+          </button>
+          <button
+            id="sort-issueKey"
+            class="sort-btn"
+            title="Issue IDのアルファベット順"
+          >
+            <span class="material-symbols-outlined type-icon">tag</span>
+            <span class="material-symbols-outlined dir-icon"
+              >arrow_downward</span
+            >
+          </button>
+          <button id="sort-priority" class="sort-btn" title="優先度順">
+            <span class="material-symbols-outlined type-icon"
+              >signal_cellular_alt</span
+            >
+            <span class="material-symbols-outlined dir-icon"
+              >arrow_downward</span
+            >
+          </button>
+          <button id="sort-status" class="sort-btn" title="Status順">
+            <span class="material-symbols-outlined type-icon">fact_check</span>
+            <span class="material-symbols-outlined dir-icon"
+              >arrow_downward</span
+            >
+          </button>
+        </div>
         <div class="spacer"></div>
         <button id="settings-btn" title="設定" class="icon-btn">
           <span class="material-symbols-outlined">settings</span>

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -192,7 +192,8 @@ async function renderList() {
 
     if (type === "priority") {
       // 降順で重みが小さい(Highest:0)が先
-      const result = getPriorityWeight(b.priority) - getPriorityWeight(a.priority);
+      const result =
+        getPriorityWeight(b.priority) - getPriorityWeight(a.priority);
       return direction === "desc" ? -result : result;
     }
 

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -192,8 +192,7 @@ async function renderList() {
 
     if (type === "priority") {
       // 降順で重みが小さい(Highest:0)が先
-      const result =
-        getPriorityWeight(b.priority) - getPriorityWeight(a.priority);
+      const result = getPriorityWeight(b.priority) - getPriorityWeight(a.priority);
       return direction === "desc" ? -result : result;
     }
 

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -39,6 +39,13 @@ const confirmMessage = document.getElementById("confirm-message");
 const confirmOkBtn = document.getElementById("confirm-ok");
 const confirmCancelBtn = document.getElementById("confirm-cancel");
 
+const sortBtns = {
+  lastAccessed: document.getElementById("sort-lastAccessed"),
+  issueKey: document.getElementById("sort-issueKey"),
+  priority: document.getElementById("sort-priority"),
+  status: document.getElementById("sort-status"),
+};
+
 let currentSettings = [];
 let currentProjectSettings = [];
 
@@ -87,11 +94,115 @@ const STATUS_COLOR_MAP = {
   Closed: "#36B37E",
 };
 
+const PRIORITY_ORDER = ["Highest", "High", "Medium", "Low", "Lowest"];
+const PRIORITY_ORDER_JA = ["最高", "高", "中", "低", "最低"];
+
+const STATUS_ORDER_MAP = {
+  // 完了系 (最高)
+  Done: 3,
+  完了: 3,
+  Resolved: 3,
+  解決済: 3,
+  Closed: 3,
+  // 進行中系
+  "In Progress": 2,
+  進行中: 2,
+  "In Review": 2,
+  レビュー中: 2,
+  // 未着手系
+  "To Do": 1,
+  未着手: 1,
+  Open: 1,
+  Reopened: 1,
+};
+
+/**
+ * 自然な順序でのIssue Keyソート (PROJ-2 < PROJ-10)
+ */
+function compareIssueKeys(a, b) {
+  const partsA = a.split("-");
+  const partsB = b.split("-");
+  if (partsA[0] !== partsB[0]) return partsA[0].localeCompare(partsB[0] || "");
+
+  const numA = parseInt(partsA[1], 10);
+  const numB = parseInt(partsB[1], 10);
+
+  if (isNaN(numA) && isNaN(numB)) return 0;
+  if (isNaN(numA)) return 1;
+  if (isNaN(numB)) return -1;
+
+  return numA - numB;
+}
+
+/**
+ * 優先度の重み取得
+ */
+function getPriorityWeight(priority) {
+  let idx = PRIORITY_ORDER.indexOf(priority);
+  if (idx === -1) idx = PRIORITY_ORDER_JA.indexOf(priority);
+  return idx === -1 ? 99 : idx;
+}
+
+/**
+ * ステータスの重み取得
+ */
+function getStatusWeight(status) {
+  return STATUS_ORDER_MAP[status] || 0;
+}
+
+/**
+ * ステータスの比較
+ * 降順: 完了(3) > 進行中(2) > 未着手(1) > その他(0)
+ * 昇順: 未着手(1) < 進行中(2) < 完了(3) < その他(0)
+ */
+function compareStatus(a, b, direction) {
+  const weightA = getStatusWeight(a.status);
+  const weightB = getStatusWeight(b.status);
+
+  if (direction === "desc") {
+    return weightB - weightA;
+  } else {
+    if (weightA === 0 && weightB !== 0) return 1;
+    if (weightA !== 0 && weightB === 0) return -1;
+    return weightA - weightB;
+  }
+}
+
 /**
  * 履歴リストのレンダリング
  */
 async function renderList() {
   const issues = await db.getAllIssues();
+  const sortSettings = await db.getSortSettings();
+  updateSortUI(sortSettings);
+
+  // ソートの適用
+  issues.sort((a, b) => {
+    const { type, direction } = sortSettings;
+
+    if (type === "lastAccessed") {
+      const result = (a.lastAccessed || 0) - (b.lastAccessed || 0);
+      return direction === "desc" ? -result : result;
+    }
+
+    if (type === "issueKey") {
+      const result = compareIssueKeys(a.issueKey, b.issueKey);
+      return direction === "desc" ? -result : result;
+    }
+
+    if (type === "priority") {
+      // 降順で重みが小さい(Highest:0)が先
+      const result = getPriorityWeight(b.priority) - getPriorityWeight(a.priority);
+      return direction === "desc" ? -result : result;
+    }
+
+    if (type === "status") {
+      return compareStatus(a, b, direction);
+    }
+
+    return 0;
+  });
+
   const settings = await db.getSettings();
   const projectSettings = await db.getProjectSettings();
   const otherCollapsed = await db.getOtherCollapsed();
@@ -309,6 +420,18 @@ function createIssueItem(issue) {
   const glyphs = document.createElement("div");
   glyphs.className = "issue-glyphs";
 
+  if (issue.status) {
+    const sColor = STATUS_COLOR_MAP[issue.status] || "#7A869A";
+    const sBadge = document.createElement("span");
+    sBadge.className = "status-badge";
+    sBadge.textContent = issue.status;
+    sBadge.style.color = sColor;
+    sBadge.style.backgroundColor = sColor + "15";
+    sBadge.style.border = `1px solid ${sColor}44`;
+    sBadge.title = `ステータス: ${issue.status}`;
+    glyphs.appendChild(sBadge);
+  }
+
   if (issue.priority) {
     const pInfo = PRIORITY_MAP[issue.priority] || {
       glyph: "•",
@@ -322,18 +445,6 @@ function createIssueItem(issue) {
     pBadge.style.border = `1px solid ${pInfo.color}44`; // 44 is approx 25% opacity
     pBadge.title = `優先度: ${issue.priority}`;
     glyphs.appendChild(pBadge);
-  }
-
-  if (issue.status) {
-    const sColor = STATUS_COLOR_MAP[issue.status] || "#7A869A";
-    const sBadge = document.createElement("span");
-    sBadge.className = "status-badge";
-    sBadge.textContent = issue.status;
-    sBadge.style.color = sColor;
-    sBadge.style.backgroundColor = sColor + "15";
-    sBadge.style.border = `1px solid ${sColor}44`;
-    sBadge.title = `ステータス: ${issue.status}`;
-    glyphs.appendChild(sBadge);
   }
 
   item.appendChild(indicators);
@@ -362,7 +473,51 @@ async function handleIssueClick(issue) {
   } else {
     chrome.tabs.create({ url: issue.url });
   }
+
+  // 最終表示時刻を即座に更新して、ソート順を反映させる
+  const sortSettings = await db.getSortSettings();
+  if (sortSettings.type === "lastAccessed") {
+    // upsertIssueを呼び出すことで、IndexedDBのlastAccessedが更新される。
+    // その後、renderListを呼び出すことでリストが再描画され、順序が更新される。
+    await db.upsertIssue({ ...issue, lastAccessed: Date.now() });
+    renderList();
+  }
 }
+
+/**
+ * ソートUIの更新
+ */
+function updateSortUI(sortSettings) {
+  Object.keys(sortBtns).forEach((type) => {
+    const btn = sortBtns[type];
+    const isActive = sortSettings.type === type;
+    btn.classList.toggle("active", isActive);
+
+    const dirIcon = btn.querySelector(".dir-icon");
+    if (isActive) {
+      dirIcon.textContent =
+        sortSettings.direction === "desc" ? "arrow_downward" : "arrow_upward";
+    } else {
+      dirIcon.textContent = "arrow_downward"; // デフォルト
+    }
+  });
+}
+
+// ソートボタンのイベントリスナー
+Object.keys(sortBtns).forEach((type) => {
+  sortBtns[type].addEventListener("click", async () => {
+    const current = await db.getSortSettings();
+    let newDirection = "desc";
+
+    if (current.type === type) {
+      newDirection = current.direction === "desc" ? "asc" : "desc";
+    }
+
+    const newSettings = { type, direction: newDirection };
+    await db.setSortSettings(newSettings);
+    renderList();
+  });
+});
 
 // 設定画面の制御ロジック
 settingsBtn.addEventListener("click", async () => {


### PR DESCRIPTION
Issueリストに、最終表示時刻、Issue ID、優先度、ステータスに基づくソート機能を追加しました。
それぞれのソート種類はボタンを一回押すごとに降順・昇順が切り替わり、設定は自動的に保存されます。
また、Issueアイテム内のバッジの並び順を変更し、ステータス文字列の長さに関わらず優先度アイコンが右端に揃うように改善しました。
さらに、ソート方向のアイコンを矢印（arrow_downward/upward）に変更することで、アコーディオン等の他のUI要素との混同を避けるようにしました。

---
*PR created automatically by Jules for task [14885660795240382220](https://jules.google.com/task/14885660795240382220) started by @masanori-satake*