### PR TITLE
feat: 設定のAboutタブをQuickLog-Soloに合わせて刷新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.10.0-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.11.0-blue)](manifest.json)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/build.py"

--- a/projects/app/db.js
+++ b/projects/app/db.js
@@ -34,6 +34,17 @@ export class IssuesDB {
     });
   }
 
+  async getIssueCount() {
+    const db = await this.open();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([this.storeName], "readonly");
+      const store = transaction.objectStore(this.storeName);
+      const request = store.count();
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
   async upsertIssue(issue) {
     const db = await this.open();
     const maxCount = await this.getMaxHistoryCount();

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Issues-Solo",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "permissions": [
     "sidePanel",

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -767,15 +767,56 @@ section:last-child {
 }
 
 .about-container {
-  line-height: 1.6;
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
-.about-container h3 {
-  margin-top: 0;
+.about-section {
+  display: flex;
+  flex-direction: column;
 }
 
-.about-container ul {
-  padding-left: 20px;
+.about-label {
+  font-size: 11px;
+  color: var(--secondary-text);
+  margin-bottom: 2px;
+}
+
+.about-value {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.stats-row {
+  flex-direction: row;
+  gap: 24px;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.about-text {
+  margin: 4px 0 0 0;
+  font-size: 13px;
+  color: var(--text-color);
+}
+
+.about-text.small {
+  font-size: 11px;
+  color: var(--secondary-text);
+}
+
+.about-text.italic {
+  font-style: italic;
+}
+
+.about-section.credits,
+.about-section.disclaimer {
+  margin-top: 4px;
 }
 
 .no-history {

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -229,25 +229,19 @@
             <section class="about-section">
               <div class="about-label">Issues-Solo</div>
               <p class="about-text">
-                Issues-Solo
-                は、プライバシー重視のJira履歴ツールです。データはブラウザ内の
-                IndexedDB に保存され、外部送信は一切行われません。GitHub Actions
-                による依存関係の検証と Google OSV-Scanner
-                による継続的な監査により、高い透明性と安全性を維持しています。
+                Issues-Solo は、プライバシー重視のJira履歴ツールです。データはブラウザ内の IndexedDB に保存され、外部送信は一切行われません。GitHub Actions による依存関係の検証と Google OSV-Scanner による継続的な監査により、高い透明性と安全性を維持しています。
               </p>
             </section>
 
             <section class="about-section credits">
               <p class="about-text small">
-                This project uses Material Design 3, an open-source design
-                system by Google.
+                This project uses Material Design 3, an open-source design system by Google.
               </p>
             </section>
 
             <section class="about-section disclaimer">
               <p class="about-text small italic">
-                【免責事項】
-                本ソフトウェアは個人開発によるオープンソースプロジェクトであり、無保証です。利用により生じたいかなる損害についても、開発者は一切の責任を負いません。自己責任でご利用ください。
+                【免責事項】 本ソフトウェアは個人開発によるオープンソースプロジェクトであり、無保証です。利用により生じたいかなる損害についても、開発者は一切の責任を負いません。自己責任でご利用ください。
               </p>
             </section>
           </div>

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -229,19 +229,25 @@
             <section class="about-section">
               <div class="about-label">Issues-Solo</div>
               <p class="about-text">
-                Issues-Solo は、プライバシー重視のJira履歴ツールです。データはブラウザ内の IndexedDB に保存され、外部送信は一切行われません。GitHub Actions による依存関係の検証と Google OSV-Scanner による継続的な監査により、高い透明性と安全性を維持しています。
+                Issues-Solo
+                は、プライバシー重視のJira履歴ツールです。データはブラウザ内の
+                IndexedDB に保存され、外部送信は一切行われません。GitHub Actions
+                による依存関係の検証と Google OSV-Scanner
+                による継続的な監査により、高い透明性と安全性を維持しています。
               </p>
             </section>
 
             <section class="about-section credits">
               <p class="about-text small">
-                This project uses Material Design 3, an open-source design system by Google.
+                This project uses Material Design 3, an open-source design
+                system by Google.
               </p>
             </section>
 
             <section class="about-section disclaimer">
               <p class="about-text small italic">
-                【免責事項】 本ソフトウェアは個人開発によるオープンソースプロジェクトであり、無保証です。利用により生じたいかなる損害についても、開発者は一切の責任を負いません。自己責任でご利用ください。
+                【免責事項】
+                本ソフトウェアは個人開発によるオープンソースプロジェクトであり、無保証です。利用により生じたいかなる損害についても、開発者は一切の責任を負いません。自己責任でご利用ください。
               </p>
             </section>
           </div>

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -201,13 +201,49 @@
         </div>
         <div class="tab-content hidden" id="about-tab">
           <div class="about-container">
-            <h3>Issues-Solo</h3>
-            <p>Version <span id="extension-version">0.5.1</span></p>
-            <p>JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能</p>
-            <hr />
-            <p>
-              この拡張機能は、プライバシーを最優先に設計されています。すべてのデータはあなたのブラウザ内にのみ保存され、外部サーバーに送信されることはありません。
-            </p>
+            <section class="about-section">
+              <div class="about-label">バージョン</div>
+              <div class="about-value" id="extension-version">v0.0.0</div>
+            </section>
+
+            <section class="about-section stats-row">
+              <div class="stat-item">
+                <span class="about-label">ホスト数</span>
+                <span class="about-value" id="stat-hosts">0</span>
+              </div>
+              <div class="stat-item">
+                <span class="about-label">プロジェクト数</span>
+                <span class="about-value" id="stat-projects">0</span>
+              </div>
+              <div class="stat-item">
+                <span class="about-label">履歴件数</span>
+                <span class="about-value" id="stat-history">0</span>
+              </div>
+            </section>
+
+            <section class="about-section">
+              <div class="about-label">開発者</div>
+              <div class="about-value">Masanori SATAKE</div>
+            </section>
+
+            <section class="about-section">
+              <div class="about-label">Issues-Solo</div>
+              <p class="about-text">
+                Issues-Solo は、プライバシー重視のJira履歴ツールです。データはブラウザ内の IndexedDB に保存され、外部送信は一切行われません。GitHub Actions による依存関係の検証と Google OSV-Scanner による継続的な監査により、高い透明性と安全性を維持しています。
+              </p>
+            </section>
+
+            <section class="about-section credits">
+              <p class="about-text small">
+                This project uses Material Design 3, an open-source design system by Google.
+              </p>
+            </section>
+
+            <section class="about-section disclaimer">
+              <p class="about-text small italic">
+                【免責事項】 本ソフトウェアは個人開発によるオープンソースプロジェクトであり、無保証です。利用により生じたいかなる損害についても、開発者は一切の責任を負いません。自己責任でご利用ください。
+              </p>
+            </section>
           </div>
         </div>
       </div>

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -525,6 +525,7 @@ settingsBtn.addEventListener("click", async () => {
   settingsPanel.classList.remove("hidden");
   renderHostSettings();
   renderProjectSettings();
+  updateAboutStats();
   const maxCount = await db.getMaxHistoryCount();
   previousMaxHistoryCount = maxCount; // 初期値を正確に保持
   updateMaxHistoryUI(maxCount);
@@ -736,6 +737,9 @@ tabButtons.forEach((btn) => {
     tabContents.forEach((c) =>
       c.classList.toggle("hidden", c.id !== `${tabName}-tab`),
     );
+    if (tabName === "about") {
+      updateAboutStats();
+    }
   });
 });
 
@@ -1006,10 +1010,26 @@ confirmAddHostBtn.addEventListener("click", async () => {
   }
 });
 
-// バージョン情報の表示
-const versionSpan = document.getElementById("extension-version");
-if (versionSpan) {
-  versionSpan.textContent = chrome.runtime.getManifest().version;
+/**
+ * バージョン情報と統計情報の表示
+ */
+async function updateAboutStats() {
+  const versionSpan = document.getElementById("extension-version");
+  if (versionSpan) {
+    versionSpan.textContent = "v" + chrome.runtime.getManifest().version;
+  }
+
+  const hosts = await db.getSettings();
+  const projects = await db.getProjectSettings();
+  const issues = await db.getAllIssues();
+
+  const statHosts = document.getElementById("stat-hosts");
+  const statProjects = document.getElementById("stat-projects");
+  const statHistory = document.getElementById("stat-history");
+
+  if (statHosts) statHosts.textContent = hosts.length;
+  if (statProjects) statProjects.textContent = projects.length;
+  if (statHistory) statHistory.textContent = issues.length;
 }
 
 // DB更新通知の受信 (Issueの追加・削除・タブ状態の変更など)

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -1021,7 +1021,7 @@ async function updateAboutStats() {
 
   const hosts = await db.getSettings();
   const projects = await db.getProjectSettings();
-  const issues = await db.getAllIssues();
+  const issueCount = await db.getIssueCount();
 
   const statHosts = document.getElementById("stat-hosts");
   const statProjects = document.getElementById("stat-projects");
@@ -1029,7 +1029,7 @@ async function updateAboutStats() {
 
   if (statHosts) statHosts.textContent = hosts.length;
   if (statProjects) statProjects.textContent = projects.length;
-  if (statHistory) statHistory.textContent = issues.length;
+  if (statHistory) statHistory.textContent = issueCount;
 }
 
 // DB更新通知の受信 (Issueの追加・削除・タブ状態の変更など)


### PR DESCRIPTION
Issues-Soloの「About」タブをQuickLog-Soloのデザインと内容に合わせて更新しました。

主な変更内容：
- **HTML/CSSの更新**: QuickLog-SoloのAboutタブを模した新しいレイアウトを導入しました。ラベル、値、統計情報の行、MD3への謝辞、および免責事項（斜体装飾含む）が含まれます。
- **統計情報の動的表示**: `sidepanel.js` に `updateAboutStats` 関数を追加し、IndexedDBおよび `chrome.storage` からホスト数、プロジェクト数、履歴件数を取得して表示するようにしました。
- **バージョンの同期**: 本変更を反映するため、バージョンを v0.11.0 に上げ、`manifest.json`, `package.json`, `package-lock.json`, `README.md` のすべてで更新を行いました。
- **クリーンアップ**: 開発中に生成された一時ファイル（server.log等）を削除し、リポジトリのクリーンな状態を維持しています。

Playwrightによるフロントエンド検証を行い、意図した通りの表示と動作になることを確認済みです。

---
*PR created automatically by Jules for task [2263903349818854406](https://jules.google.com/task/2263903349818854406) started by @masanori-satake*