### PR TITLE
多言語化（日本語・英語）への対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.11.0-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.12.0-blue)](manifest.json)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)
 
@@ -58,7 +58,8 @@ This project uses Material Design 3, an open-source design system by Google.
 
 ## 免責事項 (Disclaimer)
 
-本ソフトウェアは、個人によって開発されたオープンソース・プロジェクトであり、無保証 (AS IS) です。
-利用に際して生じたいかなる損害についても、開発者は一切の責任を負いません。 MIT ライセンスの規定に基づき、自己責任でご利用ください。
+【免責事項】
+本ソフトウェアは個人開発によるオープンソースプロジェクトであり、無保証です。利用により生じたいかなる損害についても、開発者は一切の責任を負いません。自己責任でご利用ください。
 
+[Disclaimer]
 This software is a personal open-source project and is provided "AS IS" without warranty of any kind. Use at your own risk, as per the MIT License.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -46,3 +46,11 @@ stateDiagram-v2
 
 - サイドパネル内のスタイリングは標準CSSで行い、フレームワーク由来の脆弱性リスクをゼロにする。
 - ステータス（編集中の鉛筆マーク、実在タブの点灯）をアイコンフォントを使わず、SVGまたはCSS drawingで表現する。
+
+## 免責事項 (Disclaimer)
+
+【免責事項】
+本ソフトウェアは個人開発によるオープンソースプロジェクトであり、無保証です。利用により生じたいかなる損害についても、開発者は一切の責任を負いません。自己責任でご利用ください。
+
+[Disclaimer]
+This software is a personal open-source project and is provided "AS IS" without warranty of any kind. Use at your own risk, as per the MIT License.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/build.py"

--- a/projects/app/_locales/en/messages.json
+++ b/projects/app/_locales/en/messages.json
@@ -199,5 +199,11 @@
   },
   "hidden": {
     "message": "Hidden"
+  },
+  "other": {
+    "message": "other"
+  },
+  "close": {
+    "message": "Close"
   }
 }

--- a/projects/app/_locales/en/messages.json
+++ b/projects/app/_locales/en/messages.json
@@ -1,0 +1,203 @@
+{
+  "extName": {
+    "message": "Issues-Solo"
+  },
+  "extDescription": {
+    "message": "Local-only Chrome extension to manage JIRA browsing history and editing status."
+  },
+  "actionTitle": {
+    "message": "Open Issues-Solo"
+  },
+  "sortLastAccessed": {
+    "message": "Sort by last accessed time"
+  },
+  "sortIssueKey": {
+    "message": "Sort by Issue ID (alphabetical)"
+  },
+  "sortPriority": {
+    "message": "Sort by priority"
+  },
+  "sortStatus": {
+    "message": "Sort by status"
+  },
+  "settings": {
+    "message": "Settings"
+  },
+  "loading": {
+    "message": "Loading history..."
+  },
+  "tabGeneral": {
+    "message": "General"
+  },
+  "tabProjects": {
+    "message": "Project Keys"
+  },
+  "tabAbout": {
+    "message": "About"
+  },
+  "sectionJiraSite": {
+    "message": "Jira Sites"
+  },
+  "sectionHistory": {
+    "message": "History"
+  },
+  "sectionSettings": {
+    "message": "Settings Data"
+  },
+  "sectionProject": {
+    "message": "Projects"
+  },
+  "add": {
+    "message": "Add"
+  },
+  "maxHistoryCount": {
+    "message": "Max history count"
+  },
+  "copyExport": {
+    "message": "Copy (Export)"
+  },
+  "pasteImport": {
+    "message": "Paste (Import)"
+  },
+  "importSettings": {
+    "message": "Import Settings"
+  },
+  "importModeAdd": {
+    "message": "Add (Merge)"
+  },
+  "importModeOverwrite": {
+    "message": "Overwrite"
+  },
+  "deleteAll": {
+    "message": "Delete All"
+  },
+  "version": {
+    "message": "Version"
+  },
+  "statHosts": {
+    "message": "Hosts"
+  },
+  "statProjects": {
+    "message": "Projects"
+  },
+  "statHistory": {
+    "message": "History"
+  },
+  "developer": {
+    "message": "Developer"
+  },
+  "aboutDescription": {
+    "message": "Issues-Solo is a privacy-focused Jira history tool. Data is stored in IndexedDB within your browser and is never sent externally. We maintain high transparency and security through dependency verification with GitHub Actions and continuous auditing with Google OSV-Scanner."
+  },
+  "disclaimerTitle": {
+    "message": "Disclaimer"
+  },
+  "disclaimerText": {
+    "message": "This software is a personal open-source project and is provided \"AS IS\" without warranty of any kind. Use at your own risk, as per the MIT License."
+  },
+  "confirm": {
+    "message": "Confirm"
+  },
+  "cancel": {
+    "message": "Cancel"
+  },
+  "ok": {
+    "message": "OK"
+  },
+  "addProjectTitle": {
+    "message": "Add Project Key"
+  },
+  "projectKey": {
+    "message": "Project Key"
+  },
+  "projectKeyPlaceholder": {
+    "message": "e.g., PROJ"
+  },
+  "addHostTitle": {
+    "message": "Add Jira Host"
+  },
+  "hostName": {
+    "message": "Display Name"
+  },
+  "hostNamePlaceholder": {
+    "message": "e.g., Internal Jira"
+  },
+  "hostUrl": {
+    "message": "URL / Domain"
+  },
+  "hostUrlPlaceholder": {
+    "message": "e.g., jira.example.com"
+  },
+  "noHistory": {
+    "message": "No history found."
+  },
+  "tabOpened": {
+    "message": "Tab is open"
+  },
+  "tabClosed": {
+    "message": "Tab is closed"
+  },
+  "editing": {
+    "message": "Editing"
+  },
+  "statusLabel": {
+    "message": "Status: $1",
+    "placeholders": {
+      "1": {
+        "content": "$1"
+      }
+    }
+  },
+  "priorityLabel": {
+    "message": "Priority: $1",
+    "placeholders": {
+      "1": {
+        "content": "$1"
+      }
+    }
+  },
+  "changeHistoryLimit": {
+    "message": "Change History Limit"
+  },
+  "changeHistoryLimitConfirm": {
+    "message": "Changing the maximum history limit to $1 will delete $2 old history entries that exceed the limit. Are you sure?",
+    "placeholders": {
+      "1": {
+        "content": "$1"
+      },
+      "2": {
+        "content": "$2"
+      }
+    }
+  },
+  "clearHistoryTitle": {
+    "message": "Clear All History"
+  },
+  "clearHistoryConfirm": {
+    "message": "This will delete all currently held history entries. Are you sure?"
+  },
+  "historyExportSuccess": {
+    "message": "History data copied to clipboard (NDJSON format)"
+  },
+  "clipboardError": {
+    "message": "Reading from the clipboard is not supported or permitted in this browser."
+  },
+  "historyImportSuccess": {
+    "message": "History data imported"
+  },
+  "importError": {
+    "message": "Import failed. Please make sure the correct data is on the clipboard."
+  },
+  "settingsExportSuccess": {
+    "message": "Settings data copied to clipboard (JSON format)"
+  },
+  "settingsImportSuccess": {
+    "message": "Settings data imported"
+  },
+  "visible": {
+    "message": "Visible"
+  },
+  "hidden": {
+    "message": "Hidden"
+  }
+}

--- a/projects/app/_locales/ja/messages.json
+++ b/projects/app/_locales/ja/messages.json
@@ -1,0 +1,203 @@
+{
+  "extName": {
+    "message": "Issues-Solo"
+  },
+  "extDescription": {
+    "message": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能"
+  },
+  "actionTitle": {
+    "message": "Issues-Soloを開く"
+  },
+  "sortLastAccessed": {
+    "message": "最終表示時刻順"
+  },
+  "sortIssueKey": {
+    "message": "Issue IDのアルファベット順"
+  },
+  "sortPriority": {
+    "message": "優先度順"
+  },
+  "sortStatus": {
+    "message": "Status順"
+  },
+  "settings": {
+    "message": "設定"
+  },
+  "loading": {
+    "message": "履歴を読み込み中..."
+  },
+  "tabGeneral": {
+    "message": "一般"
+  },
+  "tabProjects": {
+    "message": "プロジェクトキー"
+  },
+  "tabAbout": {
+    "message": "About"
+  },
+  "sectionJiraSite": {
+    "message": "Jira サイト"
+  },
+  "sectionHistory": {
+    "message": "履歴"
+  },
+  "sectionSettings": {
+    "message": "設定データ"
+  },
+  "sectionProject": {
+    "message": "プロジェクト"
+  },
+  "add": {
+    "message": "追加"
+  },
+  "maxHistoryCount": {
+    "message": "最大保持件数"
+  },
+  "copyExport": {
+    "message": "コピー (Export)"
+  },
+  "pasteImport": {
+    "message": "貼り付け (Import)"
+  },
+  "importSettings": {
+    "message": "インポート設定"
+  },
+  "importModeAdd": {
+    "message": "追記"
+  },
+  "importModeOverwrite": {
+    "message": "上書き"
+  },
+  "deleteAll": {
+    "message": "全削除"
+  },
+  "version": {
+    "message": "バージョン"
+  },
+  "statHosts": {
+    "message": "ホスト数"
+  },
+  "statProjects": {
+    "message": "プロジェクト数"
+  },
+  "statHistory": {
+    "message": "履歴件数"
+  },
+  "developer": {
+    "message": "開発者"
+  },
+  "aboutDescription": {
+    "message": "Issues-Solo は、プライバシー重視のJira履歴ツールです。データはブラウザ内の IndexedDB に保存され、外部送信は一切行われません。GitHub Actions による依存関係の検証と Google OSV-Scanner による継続的な監査により、高い透明性と安全性を維持しています。"
+  },
+  "disclaimerTitle": {
+    "message": "【免責事項】"
+  },
+  "disclaimerText": {
+    "message": "本ソフトウェアは個人開発によるオープンソースプロジェクトであり、無保証です。利用により生じたいかなる損害についても、開発者は一切の責任を負いません。自己責任でご利用ください。"
+  },
+  "confirm": {
+    "message": "確認"
+  },
+  "cancel": {
+    "message": "キャンセル"
+  },
+  "ok": {
+    "message": "OK"
+  },
+  "addProjectTitle": {
+    "message": "プロジェクトキーの追加"
+  },
+  "projectKey": {
+    "message": "プロジェクトキー"
+  },
+  "projectKeyPlaceholder": {
+    "message": "例: PROJ"
+  },
+  "addHostTitle": {
+    "message": "Jiraホストの追加"
+  },
+  "hostName": {
+    "message": "表示名"
+  },
+  "hostNamePlaceholder": {
+    "message": "例: 社内Jira"
+  },
+  "hostUrl": {
+    "message": "URL / ドメイン"
+  },
+  "hostUrlPlaceholder": {
+    "message": "例: jira.example.com"
+  },
+  "noHistory": {
+    "message": "履歴が見つかりません。"
+  },
+  "tabOpened": {
+    "message": "タブが開いています"
+  },
+  "tabClosed": {
+    "message": "タブは閉じています"
+  },
+  "editing": {
+    "message": "編集中"
+  },
+  "statusLabel": {
+    "message": "ステータス: $1",
+    "placeholders": {
+      "1": {
+        "content": "$1"
+      }
+    }
+  },
+  "priorityLabel": {
+    "message": "優先度: $1",
+    "placeholders": {
+      "1": {
+        "content": "$1"
+      }
+    }
+  },
+  "changeHistoryLimit": {
+    "message": "保持件数の変更"
+  },
+  "changeHistoryLimitConfirm": {
+    "message": "最大保持件数を $1 件に変更すると、制限を超える古い履歴 ($2 件) が削除されます。よろしいですか？",
+    "placeholders": {
+      "1": {
+        "content": "$1"
+      },
+      "2": {
+        "content": "$2"
+      }
+    }
+  },
+  "clearHistoryTitle": {
+    "message": "履歴の全削除"
+  },
+  "clearHistoryConfirm": {
+    "message": "現在保持されているすべての履歴エントリーを削除します。よろしいですか？"
+  },
+  "historyExportSuccess": {
+    "message": "履歴データをクリップボードにコピーしました (NDJSON形式)"
+  },
+  "clipboardError": {
+    "message": "このブラウザではクリップボードからの読み取りがサポートされていないか、許可されていません。"
+  },
+  "historyImportSuccess": {
+    "message": "履歴データをインポートしました"
+  },
+  "importError": {
+    "message": "インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。"
+  },
+  "settingsExportSuccess": {
+    "message": "設定データをクリップボードにコピーしました (JSON形式)"
+  },
+  "settingsImportSuccess": {
+    "message": "設定データをインポートしました"
+  },
+  "visible": {
+    "message": "表示中"
+  },
+  "hidden": {
+    "message": "非表示"
+  }
+}

--- a/projects/app/_locales/ja/messages.json
+++ b/projects/app/_locales/ja/messages.json
@@ -199,5 +199,11 @@
   },
   "hidden": {
     "message": "非表示"
+  },
+  "other": {
+    "message": "その他"
+  },
+  "close": {
+    "message": "閉じる"
   }
 }

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "Issues-Solo",
-  "version": "0.11.0",
-  "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
+  "name": "__MSG_extName__",
+  "version": "0.12.0",
+  "default_locale": "en",
+  "description": "__MSG_extDescription__",
   "permissions": [
     "sidePanel",
     "tabs",
@@ -33,6 +34,6 @@
     "default_path": "sidepanel.html"
   },
   "action": {
-    "default_title": "Open Issues-Solo"
+    "default_title": "__MSG_actionTitle__"
   }
 }

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -68,11 +68,7 @@
       <div class="settings-content">
         <div class="settings-header">
           <div class="settings-title" data-i18n="settings">設定</div>
-          <button
-            id="close-settings"
-            class="icon-btn"
-            data-i18n-title="close"
-          >
+          <button id="close-settings" class="icon-btn" data-i18n-title="close">
             <span class="material-symbols-outlined">close</span>
           </button>
         </div>

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -68,7 +68,11 @@
       <div class="settings-content">
         <div class="settings-header">
           <div class="settings-title" data-i18n="settings">設定</div>
-          <button id="close-settings" class="icon-btn">
+          <button
+            id="close-settings"
+            class="icon-btn"
+            data-i18n-title="close"
+          >
             <span class="material-symbols-outlined">close</span>
           </button>
         </div>

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -12,7 +12,7 @@
           <button
             id="sort-lastAccessed"
             class="sort-btn"
-            title="最終表示時刻順"
+            data-i18n-title="sortLastAccessed"
           >
             <span class="material-symbols-outlined type-icon">schedule</span>
             <span class="material-symbols-outlined dir-icon"
@@ -22,14 +22,18 @@
           <button
             id="sort-issueKey"
             class="sort-btn"
-            title="Issue IDのアルファベット順"
+            data-i18n-title="sortIssueKey"
           >
             <span class="material-symbols-outlined type-icon">tag</span>
             <span class="material-symbols-outlined dir-icon"
               >arrow_downward</span
             >
           </button>
-          <button id="sort-priority" class="sort-btn" title="優先度順">
+          <button
+            id="sort-priority"
+            class="sort-btn"
+            data-i18n-title="sortPriority"
+          >
             <span class="material-symbols-outlined type-icon"
               >signal_cellular_alt</span
             >
@@ -37,7 +41,11 @@
               >arrow_downward</span
             >
           </button>
-          <button id="sort-status" class="sort-btn" title="Status順">
+          <button
+            id="sort-status"
+            class="sort-btn"
+            data-i18n-title="sortStatus"
+          >
             <span class="material-symbols-outlined type-icon">fact_check</span>
             <span class="material-symbols-outlined dir-icon"
               >arrow_downward</span
@@ -45,7 +53,7 @@
           </button>
         </div>
         <div class="spacer"></div>
-        <button id="settings-btn" title="設定" class="icon-btn">
+        <button id="settings-btn" data-i18n-title="settings" class="icon-btn">
           <span class="material-symbols-outlined">settings</span>
         </button>
       </div>
@@ -53,46 +61,57 @@
 
     <main id="issue-list">
       <!-- 履歴がここに動的に生成される -->
-      <div class="loading">履歴を読み込み中...</div>
+      <div class="loading" data-i18n="loading">履歴を読み込み中...</div>
     </main>
 
     <div id="settings-panel" class="overlay hidden">
       <div class="settings-content">
         <div class="settings-header">
-          <div class="settings-title">設定</div>
+          <div class="settings-title" data-i18n="settings">設定</div>
           <button id="close-settings" class="icon-btn">
             <span class="material-symbols-outlined">close</span>
           </button>
         </div>
         <div class="tabs">
-          <button class="tab-btn active" data-tab="general" title="一般">
+          <button
+            class="tab-btn active"
+            data-tab="general"
+            data-i18n-title="tabGeneral"
+          >
             <span class="material-symbols-outlined">settings</span>
           </button>
-          <button class="tab-btn" data-tab="projects" title="プロジェクトキー">
+          <button
+            class="tab-btn"
+            data-tab="projects"
+            data-i18n-title="tabProjects"
+          >
             <span class="material-symbols-outlined">category</span>
           </button>
-          <button class="tab-btn" data-tab="about" title="About">
+          <button class="tab-btn" data-tab="about" data-i18n-title="tabAbout">
             <span class="material-symbols-outlined">info</span>
           </button>
         </div>
         <div class="tab-content" id="general-tab">
           <section id="jira-site-section">
-            <h4 class="section-title">Jira サイト</h4>
+            <h4 class="section-title" data-i18n="sectionJiraSite">
+              Jira サイト
+            </h4>
             <div class="host-list-container">
               <ul id="host-list"></ul>
             </div>
             <div class="host-actions">
-              <button id="add-host-btn" class="fab-btn" title="追加">
+              <button id="add-host-btn" class="fab-btn" data-i18n-title="add">
                 <span class="material-symbols-outlined">add</span>
               </button>
             </div>
           </section>
 
           <section id="history-section">
-            <h4 class="section-title">履歴</h4>
+            <h4 class="section-title" data-i18n="sectionHistory">履歴</h4>
             <div class="settings-item">
               <label for="max-history-range"
-                >最大保持件数: <span id="max-history-value">50</span></label
+                ><span data-i18n="maxHistoryCount">最大保持件数</span>:
+                <span id="max-history-value">50</span></label
               >
               <input
                 type="range"
@@ -112,15 +131,15 @@
               <div class="management-buttons">
                 <button id="export-history-btn" class="management-btn">
                   <span class="material-symbols-outlined">content_copy</span>
-                  コピー (Export)
+                  <span data-i18n="copyExport">コピー (Export)</span>
                 </button>
                 <button id="import-history-btn" class="management-btn">
                   <span class="material-symbols-outlined">content_paste</span>
-                  貼り付け (Import)
+                  <span data-i18n="pasteImport">貼り付け (Import)</span>
                 </button>
               </div>
               <div class="import-mode-selector">
-                <label>インポート設定:</label>
+                <label data-i18n="importSettings">インポート設定:</label>
                 <div class="radio-group">
                   <label
                     ><input
@@ -129,7 +148,7 @@
                       value="add"
                       checked
                     />
-                    追記</label
+                    <span data-i18n="importModeAdd">追記</span></label
                   >
                   <label
                     ><input
@@ -137,32 +156,32 @@
                       name="history-import-mode"
                       value="overwrite"
                     />
-                    上書き</label
+                    <span data-i18n="importModeOverwrite">上書き</span></label
                   >
                 </div>
               </div>
               <button id="clear-history-btn" class="management-btn danger">
                 <span class="material-symbols-outlined">delete_forever</span>
-                全削除
+                <span data-i18n="deleteAll">全削除</span>
               </button>
             </div>
           </section>
 
           <section id="data-section">
-            <h4 class="section-title">設定</h4>
+            <h4 class="section-title" data-i18n="sectionSettings">設定</h4>
             <div class="data-management">
               <div class="management-buttons">
                 <button id="export-settings-btn" class="management-btn">
                   <span class="material-symbols-outlined">content_copy</span>
-                  コピー (Export)
+                  <span data-i18n="copyExport">コピー (Export)</span>
                 </button>
                 <button id="import-settings-btn" class="management-btn">
                   <span class="material-symbols-outlined">content_paste</span>
-                  貼り付け (Import)
+                  <span data-i18n="pasteImport">貼り付け (Import)</span>
                 </button>
               </div>
               <div class="import-mode-selector">
-                <label>インポート設定:</label>
+                <label data-i18n="importSettings">インポート設定:</label>
                 <div class="radio-group">
                   <label
                     ><input
@@ -171,7 +190,7 @@
                       value="add"
                       checked
                     />
-                    追記</label
+                    <span data-i18n="importModeAdd">追記</span></label
                   >
                   <label
                     ><input
@@ -179,7 +198,7 @@
                       name="settings-import-mode"
                       value="overwrite"
                     />
-                    上書き</label
+                    <span data-i18n="importModeOverwrite">上書き</span></label
                   >
                 </div>
               </div>
@@ -188,12 +207,18 @@
         </div>
         <div class="tab-content hidden" id="projects-tab">
           <section>
-            <h4 class="section-title">プロジェクト</h4>
+            <h4 class="section-title" data-i18n="sectionProject">
+              プロジェクト
+            </h4>
             <div class="project-list-container">
               <ul id="project-list"></ul>
             </div>
             <div class="project-actions">
-              <button id="add-project-btn" class="fab-btn" title="追加">
+              <button
+                id="add-project-btn"
+                class="fab-btn"
+                data-i18n-title="add"
+              >
                 <span class="material-symbols-outlined">add</span>
               </button>
             </div>
@@ -202,33 +227,37 @@
         <div class="tab-content hidden" id="about-tab">
           <div class="about-container">
             <section class="about-section">
-              <div class="about-label">バージョン</div>
+              <div class="about-label" data-i18n="version">バージョン</div>
               <div class="about-value" id="extension-version">v0.0.0</div>
             </section>
 
             <section class="about-section stats-row">
               <div class="stat-item">
-                <span class="about-label">ホスト数</span>
+                <span class="about-label" data-i18n="statHosts">ホスト数</span>
                 <span class="about-value" id="stat-hosts">0</span>
               </div>
               <div class="stat-item">
-                <span class="about-label">プロジェクト数</span>
+                <span class="about-label" data-i18n="statProjects"
+                  >プロジェクト数</span
+                >
                 <span class="about-value" id="stat-projects">0</span>
               </div>
               <div class="stat-item">
-                <span class="about-label">履歴件数</span>
+                <span class="about-label" data-i18n="statHistory"
+                  >履歴件数</span
+                >
                 <span class="about-value" id="stat-history">0</span>
               </div>
             </section>
 
             <section class="about-section">
-              <div class="about-label">開発者</div>
+              <div class="about-label" data-i18n="developer">開発者</div>
               <div class="about-value">Masanori SATAKE</div>
             </section>
 
             <section class="about-section">
               <div class="about-label">Issues-Solo</div>
-              <p class="about-text">
+              <p class="about-text" data-i18n="aboutDescription">
                 Issues-Solo
                 は、プライバシー重視のJira履歴ツールです。データはブラウザ内の
                 IndexedDB に保存され、外部送信は一切行われません。GitHub Actions
@@ -246,8 +275,10 @@
 
             <section class="about-section disclaimer">
               <p class="about-text small italic">
-                【免責事項】
-                本ソフトウェアは個人開発によるオープンソースプロジェクトであり、無保証です。利用により生じたいかなる損害についても、開発者は一切の責任を負いません。自己責任でご利用ください。
+                <span data-i18n="disclaimerTitle">【免責事項】</span>
+                <span data-i18n="disclaimerText">
+                  本ソフトウェアは個人開発によるオープンソースプロジェクトであり、無保証です。利用により生じたいかなる損害についても、開発者は一切の責任を負いません。自己責任でご利用ください。
+                </span>
               </p>
             </section>
           </div>
@@ -257,43 +288,72 @@
 
     <div id="confirm-dialog" class="overlay hidden">
       <div class="dialog">
-        <h3 id="confirm-title">確認</h3>
+        <h3 id="confirm-title" data-i18n="confirm">確認</h3>
         <p id="confirm-message"></p>
         <div class="dialog-actions">
-          <button id="confirm-cancel" class="text-btn">キャンセル</button>
-          <button id="confirm-ok" class="text-btn danger">OK</button>
+          <button id="confirm-cancel" class="text-btn" data-i18n="cancel">
+            キャンセル
+          </button>
+          <button id="confirm-ok" class="text-btn danger" data-i18n="ok">
+            OK
+          </button>
         </div>
       </div>
     </div>
 
     <div id="add-project-dialog" class="overlay hidden">
       <div class="dialog">
-        <h3>プロジェクトキーの追加</h3>
+        <h3 data-i18n="addProjectTitle">プロジェクトキーの追加</h3>
         <div class="input-field">
-          <label for="project-key-input">プロジェクトキー</label>
-          <input type="text" id="project-key-input" placeholder="例: PROJ" />
+          <label for="project-key-input" data-i18n="projectKey"
+            >プロジェクトキー</label
+          >
+          <input
+            type="text"
+            id="project-key-input"
+            data-i18n-placeholder="projectKeyPlaceholder"
+            placeholder="例: PROJ"
+          />
         </div>
         <div class="dialog-actions">
-          <button id="cancel-add-project" class="text-btn">キャンセル</button>
-          <button id="confirm-add-project" class="text-btn">OK</button>
+          <button id="cancel-add-project" class="text-btn" data-i18n="cancel">
+            キャンセル
+          </button>
+          <button id="confirm-add-project" class="text-btn" data-i18n="ok">
+            OK
+          </button>
         </div>
       </div>
     </div>
 
     <div id="add-host-dialog" class="overlay hidden">
       <div class="dialog">
-        <h3>Jiraホストの追加</h3>
+        <h3 data-i18n="addHostTitle">Jiraホストの追加</h3>
         <div class="input-field">
-          <label for="host-name">表示名</label>
-          <input type="text" id="host-name" placeholder="例: 社内Jira" />
+          <label for="host-name" data-i18n="hostName">表示名</label>
+          <input
+            type="text"
+            id="host-name"
+            data-i18n-placeholder="hostNamePlaceholder"
+            placeholder="例: 社内Jira"
+          />
         </div>
         <div class="input-field">
-          <label for="host-url">URL / ドメイン</label>
-          <input type="text" id="host-url" placeholder="例: jira.example.com" />
+          <label for="host-url" data-i18n="hostUrl">URL / ドメイン</label>
+          <input
+            type="text"
+            id="host-url"
+            data-i18n-placeholder="hostUrlPlaceholder"
+            placeholder="例: jira.example.com"
+          />
         </div>
         <div class="dialog-actions">
-          <button id="cancel-add-host" class="text-btn">キャンセル</button>
-          <button id="confirm-add-host" class="text-btn">追加</button>
+          <button id="cancel-add-host" class="text-btn" data-i18n="cancel">
+            キャンセル
+          </button>
+          <button id="confirm-add-host" class="text-btn" data-i18n="add">
+            追加
+          </button>
         </div>
       </div>
     </div>

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -169,6 +169,35 @@ function compareStatus(a, b, direction) {
 }
 
 /**
+ * i18n対応: data-i18n属性を持つ要素のテキストを更新
+ */
+function applyTranslations() {
+  document.querySelectorAll("[data-i18n]").forEach((el) => {
+    const key = el.getAttribute("data-i18n");
+    const message = chrome.i18n.getMessage(key);
+    if (message) {
+      el.textContent = message;
+    }
+  });
+
+  document.querySelectorAll("[data-i18n-title]").forEach((el) => {
+    const key = el.getAttribute("data-i18n-title");
+    const message = chrome.i18n.getMessage(key);
+    if (message) {
+      el.setAttribute("title", message);
+    }
+  });
+
+  document.querySelectorAll("[data-i18n-placeholder]").forEach((el) => {
+    const key = el.getAttribute("data-i18n-placeholder");
+    const message = chrome.i18n.getMessage(key);
+    if (message) {
+      el.setAttribute("placeholder", message);
+    }
+  });
+}
+
+/**
  * 履歴リストのレンダリング
  */
 async function renderList() {
@@ -214,7 +243,7 @@ async function renderList() {
     listElement.textContent = "";
     const noHistory = document.createElement("div");
     noHistory.className = "no-history";
-    noHistory.textContent = "履歴が見つかりません。";
+    noHistory.textContent = chrome.i18n.getMessage("noHistory");
     listElement.appendChild(noHistory);
     return;
   }
@@ -393,12 +422,12 @@ function createIssueItem(issue) {
   const openIndicator = document.createElement("div");
   openIndicator.className = `indicator ${issue.isOpened ? "is-opened" : ""}`;
   openIndicator.title = issue.isOpened
-    ? "タブが開いています"
-    : "タブは閉じています";
+    ? chrome.i18n.getMessage("tabOpened")
+    : chrome.i18n.getMessage("tabClosed");
 
   const editIndicator = document.createElement("div");
   editIndicator.className = `indicator ${issue.isEditing ? "is-editing" : ""}`;
-  editIndicator.title = issue.isEditing ? "編集中" : "";
+  editIndicator.title = issue.isEditing ? chrome.i18n.getMessage("editing") : "";
 
   indicators.appendChild(openIndicator);
   indicators.appendChild(editIndicator);
@@ -429,7 +458,7 @@ function createIssueItem(issue) {
     sBadge.style.color = sColor;
     sBadge.style.backgroundColor = sColor + "15";
     sBadge.style.border = `1px solid ${sColor}44`;
-    sBadge.title = `ステータス: ${issue.status}`;
+    sBadge.title = chrome.i18n.getMessage("statusLabel", [issue.status]);
     glyphs.appendChild(sBadge);
   }
 
@@ -444,7 +473,7 @@ function createIssueItem(issue) {
     pBadge.style.color = pInfo.color;
     pBadge.style.backgroundColor = pInfo.color + "15"; // 15 is approx 8% opacity
     pBadge.style.border = `1px solid ${pInfo.color}44`; // 44 is approx 25% opacity
-    pBadge.title = `優先度: ${issue.priority}`;
+    pBadge.title = chrome.i18n.getMessage("priorityLabel", [issue.priority]);
     glyphs.appendChild(pBadge);
   }
 
@@ -569,10 +598,11 @@ maxHistoryRange.addEventListener("change", async () => {
 
   if (newCount < previousMaxHistoryCount && currentIssues.length > newCount) {
     showConfirm(
-      "保持件数の変更",
-      `最大保持件数を ${newCount} 件に変更すると、制限を超える古い履歴 (${
-        currentIssues.length - newCount
-      } 件) が削除されます。よろしいですか？`,
+      chrome.i18n.getMessage("changeHistoryLimit"),
+      chrome.i18n.getMessage("changeHistoryLimitConfirm", [
+        newCount.toString(),
+        (currentIssues.length - newCount).toString(),
+      ]),
       async () => {
         maxHistoryValue.textContent = newCount;
         await db.setMaxHistoryCount(newCount);
@@ -623,8 +653,8 @@ function showConfirm(title, message, onOk, onCancel) {
 // 履歴の全削除
 clearHistoryBtn.addEventListener("click", () => {
   showConfirm(
-    "履歴の全削除",
-    "現在保持されているすべての履歴エントリーを削除します。よろしいですか？",
+    chrome.i18n.getMessage("clearHistoryTitle"),
+    chrome.i18n.getMessage("clearHistoryConfirm"),
     async () => {
       await db.clearAllIssues();
       renderList();
@@ -638,7 +668,7 @@ exportHistoryBtn.addEventListener("click", async () => {
   const ndjson = issues.map((i) => JSON.stringify(i)).join("\n");
   try {
     await navigator.clipboard.writeText(ndjson);
-    alert("履歴データをクリップボードにコピーしました (NDJSON形式)");
+    alert(chrome.i18n.getMessage("historyExportSuccess"));
   } catch (err) {
     console.error("Failed to copy history", err);
   }
@@ -648,9 +678,7 @@ exportHistoryBtn.addEventListener("click", async () => {
 importHistoryBtn.addEventListener("click", async () => {
   try {
     if (!navigator.clipboard || !navigator.clipboard.readText) {
-      alert(
-        "このブラウザではクリップボードからの読み取りがサポートされていないか、許可されていません。",
-      );
+      alert(chrome.i18n.getMessage("clipboardError"));
       return;
     }
     const text = await navigator.clipboard.readText();
@@ -659,12 +687,10 @@ importHistoryBtn.addEventListener("click", async () => {
     ).value;
     await db.importIssues(text, mode);
     renderList();
-    alert("履歴データをインポートしました");
+    alert(chrome.i18n.getMessage("historyImportSuccess"));
   } catch (err) {
     console.error("Failed to import history", err);
-    alert(
-      "インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。",
-    );
+    alert(chrome.i18n.getMessage("importError"));
   }
 });
 
@@ -690,7 +716,7 @@ exportSettingsBtn.addEventListener("click", async () => {
 
   try {
     await navigator.clipboard.writeText(JSON.stringify(data, null, 2));
-    alert("設定データをクリップボードにコピーしました (JSON形式)");
+    alert(chrome.i18n.getMessage("settingsExportSuccess"));
   } catch (err) {
     console.error("Failed to copy settings", err);
   }
@@ -700,9 +726,7 @@ exportSettingsBtn.addEventListener("click", async () => {
 importSettingsBtn.addEventListener("click", async () => {
   try {
     if (!navigator.clipboard || !navigator.clipboard.readText) {
-      alert(
-        "このブラウザではクリップボードからの読み取りがサポートされていないか、許可されていません。",
-      );
+      alert(chrome.i18n.getMessage("clipboardError"));
       return;
     }
     const text = await navigator.clipboard.readText();
@@ -715,12 +739,10 @@ importSettingsBtn.addEventListener("click", async () => {
     renderProjectSettings();
     const maxCount = await db.getMaxHistoryCount();
     updateMaxHistoryUI(maxCount);
-    alert("設定データをインポートしました");
+    alert(chrome.i18n.getMessage("settingsImportSuccess"));
   } catch (err) {
     console.error("Failed to import settings", err);
-    alert(
-      "インポートに失敗しました。クリップボードに正しいデータがあるか確認してください。",
-    );
+    alert(chrome.i18n.getMessage("importError"));
   }
 });
 
@@ -904,7 +926,9 @@ async function renderHostSettings() {
 
     const toggle = document.createElement("div");
     toggle.className = "visibility-toggle";
-    toggle.title = host.visible ? "表示中" : "非表示";
+    toggle.title = host.visible
+      ? chrome.i18n.getMessage("visible")
+      : chrome.i18n.getMessage("hidden");
     const toggleIcon = document.createElement("span");
     toggleIcon.className = "material-symbols-outlined";
     toggleIcon.textContent = host.visible ? "visibility" : "visibility_off";
@@ -1051,4 +1075,5 @@ chrome.storage.onChanged.addListener((changes) => {
   }
 });
 
+applyTranslations();
 renderList();

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -427,7 +427,9 @@ function createIssueItem(issue) {
 
   const editIndicator = document.createElement("div");
   editIndicator.className = `indicator ${issue.isEditing ? "is-editing" : ""}`;
-  editIndicator.title = issue.isEditing ? chrome.i18n.getMessage("editing") : "";
+  editIndicator.title = issue.isEditing
+    ? chrome.i18n.getMessage("editing")
+    : "";
 
   indicators.appendChild(openIndicator);
   indicators.appendChild(editIndicator);

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -172,27 +172,27 @@ function compareStatus(a, b, direction) {
  * i18n対応: data-i18n属性を持つ要素のテキストを更新
  */
 function applyTranslations() {
-  document.querySelectorAll("[data-i18n]").forEach((el) => {
-    const key = el.getAttribute("data-i18n");
-    const message = chrome.i18n.getMessage(key);
-    if (message) {
-      el.textContent = message;
-    }
-  });
+  const selectors = [
+    "[data-i18n]",
+    "[data-i18n-title]",
+    "[data-i18n-placeholder]",
+  ];
+  document.querySelectorAll(selectors.join(", ")).forEach((el) => {
+    const textKey = el.dataset.i18n;
+    const titleKey = el.dataset.i18nTitle;
+    const placeholderKey = el.dataset.i18nPlaceholder;
 
-  document.querySelectorAll("[data-i18n-title]").forEach((el) => {
-    const key = el.getAttribute("data-i18n-title");
-    const message = chrome.i18n.getMessage(key);
-    if (message) {
-      el.setAttribute("title", message);
+    if (textKey) {
+      const message = chrome.i18n.getMessage(textKey);
+      if (message) el.textContent = message;
     }
-  });
-
-  document.querySelectorAll("[data-i18n-placeholder]").forEach((el) => {
-    const key = el.getAttribute("data-i18n-placeholder");
-    const message = chrome.i18n.getMessage(key);
-    if (message) {
-      el.setAttribute("placeholder", message);
+    if (titleKey) {
+      const message = chrome.i18n.getMessage(titleKey);
+      if (message) el.setAttribute("title", message);
+    }
+    if (placeholderKey) {
+      const message = chrome.i18n.getMessage(placeholderKey);
+      if (message) el.setAttribute("placeholder", message);
     }
   });
 }
@@ -389,7 +389,7 @@ async function renderList() {
         otherHeader.appendChild(glyph);
 
         const name = document.createElement("span");
-        name.textContent = "other";
+        name.textContent = chrome.i18n.getMessage("other") || "other";
         otherHeader.appendChild(name);
 
         otherHeader.addEventListener("click", async () => {
@@ -427,9 +427,7 @@ function createIssueItem(issue) {
 
   const editIndicator = document.createElement("div");
   editIndicator.className = `indicator ${issue.isEditing ? "is-editing" : ""}`;
-  editIndicator.title = issue.isEditing
-    ? chrome.i18n.getMessage("editing")
-    : "";
+  editIndicator.title = issue.isEditing ? chrome.i18n.getMessage("editing") : "";
 
   indicators.appendChild(openIndicator);
   indicators.appendChild(editIndicator);

--- a/projects/web/i18n.js
+++ b/projects/web/i18n.js
@@ -1,0 +1,164 @@
+const translations = {
+  en: {
+    title:
+      "Issues-Solo - Local-only Chrome extension to manage JIRA browsing history and editing status",
+    usage: "Usage",
+    privacy: "Privacy Policy",
+    tagline:
+      "〜Local-only Chrome extension to manage JIRA browsing history and editing status〜",
+    cta: "Add to Chrome Web Store",
+    projectOverview: "Project Overview",
+    overviewText:
+      "Issues-Solo is a JIRA-specific browsing history and editing status management tool designed with privacy as the top priority. It safely records 'which task you saw and when' and 'how much you have written' within your browser, supporting the restoration of your work context.",
+    features: "Features",
+    featureJira: "JIRA Specialized",
+    featureJiraText:
+      "Automatically extracts issue keys and titles on the atlassian.net domain and lists them as browsing history.",
+    featureEditing: "Save Editing Status",
+    featureEditingText:
+      "Detects changes in comments or descriptions being entered and saves them. Even if you close the browser, you can restore the 'work-in-progress' state.",
+    featureLocal: "Complete Local Execution",
+    featureLocalText:
+      "All data is saved in IndexedDB within the browser. No data is ever sent to external servers.",
+    featureM3: "Material 3 UI",
+    featureM3Text:
+      "Adopts Google Material 3 (M3) design. Operates comfortably in the side panel without interfering with your work.",
+    install: "How to Install",
+    installStep1: "Access the Chrome Web Store.",
+    installStep2: 'Click the "Add to Chrome" button.',
+    installStep3:
+      "Pinning the extension makes it easier to access from the side panel at any time.",
+    copyright: "© 2025 Issues-Solo. All rights reserved.",
+    privacyTitle: "Privacy Policy - Issues-Solo",
+    usageTitle: "Usage - Issues-Solo",
+    backToHome: "Back to Home",
+    privacyPolicy: "Privacy Policy",
+    usageGuide: "Usage Guide",
+    langEn: "English",
+    langJa: "日本語",
+    privacyHeader1: "1. Data Collection and Use",
+    privacyText1:
+      "Issues-Solo collects JIRA issue keys, titles, and the editing status of input forms to improve user convenience. All of this data is stored within the user's browser (IndexedDB) and is used only to provide the functions of this extension.",
+    privacyHeader2: "2. Data Transmission",
+    privacyText2:
+      "Collected data is never sent to external servers. This extension is designed (Local-Only) not to transmit data over the internet.",
+    privacyHeader3: "3. Third-Party Measurement",
+    privacyText3:
+      "This extension and introduction website do not use any access analysis tools such as Google Analytics or advertising tracking.",
+    privacyHeader4: "4. Data Deletion",
+    privacyText4:
+      "Users can delete all locally stored data by uninstalling the extension.",
+    usageHeader1: "1. Automatic History Recording",
+    usageText1:
+      "When you display a JIRA (atlassian.net) issue page, the issue key and title are automatically saved as history.",
+    usageHeader2: "2. Opening the Side Panel",
+    usageText2:
+      "Click the extension icon in the browser toolbar or select 'Issues-Solo' from the side panel to open the panel.",
+    usageHeader3: "3. Checking History and Navigation",
+    usageText3:
+      "Clicking on a history entry in the side panel will switch to the corresponding JIRA issue tab or open it in a new tab.",
+    usageHeader4: "4. Managing Editing Status (Work-in-Progress)",
+    usageText4:
+      "The 'Editing' status is detected when you are editing a JIRA comment field or description. This state is maintained even if you close or restart the browser and can be checked from the side panel.",
+    top: "Top",
+  },
+  ja: {
+    title:
+      "Issues-Solo - JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
+    usage: "使い方",
+    privacy: "プライバシーポリシー",
+    tagline: "〜JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能〜",
+    cta: "Chrome ウェブストアで追加",
+    projectOverview: "プロジェクト概要",
+    overviewText:
+      "Issues-Soloは、プライバシーを最優先に設計された、JIRA専用の閲覧履歴・編集状態管理ツールです。「どのタスクをいつ見たか」「どこまで書き込んだか」をブラウザ内に安全に記録し、あなたの作業の文脈復元をサポートします。",
+    features: "特徴",
+    featureJira: "JIRA特化",
+    featureJiraText:
+      "atlassian.netドメイン上の課題キーとタイトルを自動抽出し、閲覧履歴としてリスト化します。",
+    featureEditing: "編集状態の保存",
+    featureEditingText:
+      "入力中のコメントや説明文の変更を検知し、保存。ブラウザを閉じても「書きかけ」の状態を復元できます。",
+    featureLocal: "完全ローカル実行",
+    featureLocalText:
+      "すべてのデータはブラウザ内の IndexedDB に保存されます。外部サーバーへの送信は一切行われません。",
+    featureM3: "Material 3 UI",
+    featureM3Text:
+      "Google Material 3 (M3) デザインを採用。サイドパネルで作業を邪魔せず快適に操作できます。",
+    install: "インストール方法",
+    installStep1: "Chrome ウェブストアにアクセスします。",
+    installStep2: "「Chromeに追加」ボタンをクリックします。",
+    installStep3:
+      "拡張機能の固定をオンにすると、サイドパネルからいつでもアクセスしやすくなります。",
+    copyright: "© 2025 Issues-Solo. All rights reserved.",
+    privacyTitle: "プライバシーポリシー - Issues-Solo",
+    usageTitle: "使い方 - Issues-Solo",
+    backToHome: "ホームに戻る",
+    privacyPolicy: "プライバシーポリシー",
+    usageGuide: "使い方",
+    langEn: "English",
+    langJa: "日本語",
+    privacyHeader1: "1. データの収集と利用",
+    privacyText1:
+      "Issues-Solo は、利用者の利便性向上のため、JIRAの課題キー、タイトル、および入力フォームの編集状態を収集します。これらのデータはすべて利用者のブラウザ内（IndexedDB）に保存され、本拡張機能の機能提供のためにのみ利用されます。",
+    privacyHeader2: "2. データの送信",
+    privacyText2:
+      "収集されたデータが外部サーバーに送信されることは一切ありません。本拡張機能は、インターネット経由でのデータ送信を行わない設計（Local-Only）となっています。",
+    privacyHeader3: "3. サードパーティによる計測",
+    privacyText3:
+      "本拡張機能および紹介用ウェブサイトでは、Google Analytics などのアクセス解析ツールや広告トラッキングなどは一切使用していません。",
+    privacyHeader4: "4. データの削除",
+    privacyText4:
+      "利用者は、拡張機能をアンインストールすることで、ローカルに保存されたすべてのデータを削除することができます。",
+    usageHeader1: "1. 履歴の自動記録",
+    usageText1:
+      "JIRA（atlassian.net）の課題ページを表示すると、自動的にその課題キーとタイトルが履歴として保存されます。",
+    usageHeader2: "2. サイドパネルを開く",
+    usageText2:
+      "ブラウザのツールバーにある拡張機能アイコンをクリック、またはサイドパネルから「Issues-Solo」を選択してパネルを開きます。",
+    usageHeader3: "3. 履歴の確認と移動",
+    usageText3:
+      "サイドパネルに表示された履歴リストをクリックすると、該当するJIRA課題のタブに切り替わるか、新しいタブで開きます。",
+    usageHeader4: "4. 編集状態（書きかけ）の管理",
+    usageText4:
+      "JIRAのコメント欄や説明文を編集しているときに「編集中」の状態が検知されます。ブラウザを閉じたり再起動したりしても、その状態は保持され、サイドパネルから確認できます。",
+    top: "トップ",
+  },
+};
+
+function applyTranslations() {
+  const userLang = navigator.language.startsWith("ja") ? "ja" : "en";
+  const lang = localStorage.getItem("preferred-lang") || userLang;
+  const t = translations[lang];
+
+  document.querySelectorAll("[data-i18n]").forEach((el) => {
+    const key = el.getAttribute("data-i18n");
+    if (t[key]) {
+      if (el.tagName === "INPUT" || el.tagName === "TEXTAREA") {
+        el.placeholder = t[key];
+      } else {
+        el.textContent = t[key];
+      }
+    }
+  });
+
+  document.title = t.title || document.title;
+  const titleEl = document.querySelector('meta[name="title"]');
+  if (titleEl) titleEl.setAttribute("content", t.title);
+
+  // Update language switcher active state if it exists
+  document.querySelectorAll(".lang-switch").forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.lang === lang);
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  applyTranslations();
+
+  document.querySelectorAll(".lang-switch").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      localStorage.setItem("preferred-lang", btn.dataset.lang);
+      applyTranslations();
+    });
+  });
+});

--- a/projects/web/index.html
+++ b/projects/web/index.html
@@ -192,9 +192,7 @@
           <li data-i18n="installStep1">
             Chrome ウェブストアにアクセスします。
           </li>
-          <li data-i18n="installStep2">
-            「Chromeに追加」ボタンをクリックします。
-          </li>
+          <li data-i18n="installStep2">「Chromeに追加」ボタンをクリックします。</li>
           <li data-i18n="installStep3">
             拡張機能の固定をオンにすると、サイドパネルからいつでもアクセスしやすくなります。
           </li>

--- a/projects/web/index.html
+++ b/projects/web/index.html
@@ -3,9 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>
-      Issues-Solo - JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能
-    </title>
+    <title>Issues-Solo</title>
     <style>
       :root {
         --md-sys-color-primary: #0061a4;
@@ -29,6 +27,25 @@
         align-items: center;
         padding: 1rem 2rem;
         border-bottom: 1px solid var(--md-sys-color-outline);
+      }
+      .lang-switcher {
+        display: flex;
+        gap: 0.5rem;
+        margin-left: 1.5rem;
+      }
+      .lang-switch {
+        cursor: pointer;
+        background: none;
+        border: 1px solid var(--md-sys-color-outline);
+        border-radius: 4px;
+        padding: 0.2rem 0.5rem;
+        font-size: 0.8rem;
+        color: var(--md-sys-color-on-surface);
+      }
+      .lang-switch.active {
+        background-color: var(--md-sys-color-primary);
+        color: var(--md-sys-color-on-primary);
+        border-color: var(--md-sys-color-primary);
       }
       .logo {
         display: flex;
@@ -103,54 +120,65 @@
   <body>
     <header>
       <a href="index.html" class="logo"> Issues-Solo </a>
-      <nav>
-        <a href="usage.html">使い方</a>
-        <a href="privacy.html">プライバシーポリシー</a>
+      <nav style="display: flex; align-items: center">
+        <a href="usage.html" data-i18n="usage">使い方</a>
+        <a href="privacy.html" data-i18n="privacy">プライバシーポリシー</a>
+        <div class="lang-switcher">
+          <button class="lang-switch" data-lang="en" data-i18n="langEn">
+            English
+          </button>
+          <button class="lang-switch" data-lang="ja" data-i18n="langJa">
+            日本語
+          </button>
+        </div>
       </nav>
     </header>
 
     <main>
       <h1>Issues-Solo</h1>
-      <p class="tagline">
+      <p class="tagline" data-i18n="tagline">
         〜JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能〜
       </p>
-      <a href="https://chrome.google.com/webstore" class="cta-button"
+      <a
+        href="https://chrome.google.com/webstore"
+        class="cta-button"
+        data-i18n="cta"
         >Chrome ウェブストアで追加</a
       >
 
       <section>
-        <h2>プロジェクト概要</h2>
-        <p>
+        <h2 data-i18n="projectOverview">プロジェクト概要</h2>
+        <p data-i18n="overviewText">
           Issues-Soloは、プライバシーを最優先に設計された、JIRA専用の閲覧履歴・編集状態管理ツールです。
           「どのタスクをいつ見たか」「どこまで書き込んだか」をブラウザ内に安全に記録し、あなたの作業の文脈復元をサポートします。
         </p>
       </section>
 
       <section>
-        <h2>特徴</h2>
+        <h2 data-i18n="features">特徴</h2>
         <div class="features">
           <div class="feature-item">
-            <h3>JIRA特化</h3>
-            <p>
+            <h3 data-i18n="featureJira">JIRA特化</h3>
+            <p data-i18n="featureJiraText">
               atlassian.netドメイン上の課題キーとタイトルを自動抽出し、閲覧履歴としてリスト化します。
             </p>
           </div>
           <div class="feature-item">
-            <h3>編集状態の保存</h3>
-            <p>
+            <h3 data-i18n="featureEditing">編集状態の保存</h3>
+            <p data-i18n="featureEditingText">
               入力中のコメントや説明文の変更を検知し、保存。ブラウザを閉じても「書きかけ」の状態を復元できます。
             </p>
           </div>
           <div class="feature-item">
-            <h3>完全ローカル実行</h3>
-            <p>
+            <h3 data-i18n="featureLocal">完全ローカル実行</h3>
+            <p data-i18n="featureLocalText">
               すべてのデータはブラウザ内の IndexedDB
               に保存されます。外部サーバーへの送信は一切行われません。
             </p>
           </div>
           <div class="feature-item">
-            <h3>Material 3 UI</h3>
-            <p>
+            <h3 data-i18n="featureM3">Material 3 UI</h3>
+            <p data-i18n="featureM3Text">
               Google Material 3 (M3)
               デザインを採用。サイドパネルで作業を邪魔せず快適に操作できます。
             </p>
@@ -159,14 +187,13 @@
       </section>
 
       <section>
-        <h2>インストール方法</h2>
+        <h2 data-i18n="install">インストール方法</h2>
         <ol style="text-align: left; display: inline-block">
-          <li>
-            <a href="https://chrome.google.com/webstore">Chrome ウェブストア</a
-            >にアクセスします。
+          <li data-i18n="installStep1">
+            Chrome ウェブストアにアクセスします。
           </li>
-          <li>「Chromeに追加」ボタンをクリックします。</li>
-          <li>
+          <li data-i18n="installStep2">「Chromeに追加」ボタンをクリックします。</li>
+          <li data-i18n="installStep3">
             拡張機能の固定をオンにすると、サイドパネルからいつでもアクセスしやすくなります。
           </li>
         </ol>
@@ -174,7 +201,8 @@
     </main>
 
     <footer>
-      <p>&copy; 2025 Issues-Solo. All rights reserved.</p>
+      <p data-i18n="copyright">&copy; 2025 Issues-Solo. All rights reserved.</p>
     </footer>
+    <script src="i18n.js"></script>
   </body>
 </html>

--- a/projects/web/index.html
+++ b/projects/web/index.html
@@ -192,7 +192,9 @@
           <li data-i18n="installStep1">
             Chrome ウェブストアにアクセスします。
           </li>
-          <li data-i18n="installStep2">「Chromeに追加」ボタンをクリックします。</li>
+          <li data-i18n="installStep2">
+            「Chromeに追加」ボタンをクリックします。
+          </li>
           <li data-i18n="installStep3">
             拡張機能の固定をオンにすると、サイドパネルからいつでもアクセスしやすくなります。
           </li>

--- a/projects/web/privacy.html
+++ b/projects/web/privacy.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>プライバシーポリシー - Issues-Solo</title>
+    <title>Issues-Solo</title>
     <style>
       :root {
         --md-sys-color-primary: #0061a4;
@@ -24,6 +24,25 @@
         align-items: center;
         padding: 1rem 2rem;
         border-bottom: 1px solid var(--md-sys-color-outline);
+      }
+      .lang-switcher {
+        display: flex;
+        gap: 0.5rem;
+        margin-left: 1.5rem;
+      }
+      .lang-switch {
+        cursor: pointer;
+        background: none;
+        border: 1px solid var(--md-sys-color-outline);
+        border-radius: 4px;
+        padding: 0.2rem 0.5rem;
+        font-size: 0.8rem;
+        color: var(--md-sys-color-on-surface);
+      }
+      .lang-switch.active {
+        background-color: var(--md-sys-color-primary);
+        color: var(--md-sys-color-on-primary);
+        border-color: var(--md-sys-color-primary);
       }
       .logo {
         font-weight: bold;
@@ -53,44 +72,55 @@
   <body>
     <header>
       <a href="index.html" class="logo">Issues-Solo</a>
+      <nav style="display: flex; align-items: center">
+        <div class="lang-switcher">
+          <button class="lang-switch" data-lang="en" data-i18n="langEn">
+            English
+          </button>
+          <button class="lang-switch" data-lang="ja" data-i18n="langJa">
+            日本語
+          </button>
+        </div>
+      </nav>
     </header>
 
     <main>
-      <h1>プライバシーポリシー</h1>
+      <h1 data-i18n="privacyPolicy">プライバシーポリシー</h1>
 
       <section>
-        <h2>1. データの収集と利用</h2>
-        <p>
+        <h2 data-i18n="privacyHeader1">1. データの収集と利用</h2>
+        <p data-i18n="privacyText1">
           Issues-Solo
           は、利用者の利便性向上のため、JIRAの課題キー、タイトル、および入力フォームの編集状態を収集します。これらのデータはすべて利用者のブラウザ内（IndexedDB）に保存され、本拡張機能の機能提供のためにのみ利用されます。
         </p>
       </section>
 
       <section>
-        <h2>2. データの送信</h2>
-        <p>
+        <h2 data-i18n="privacyHeader2">2. データの送信</h2>
+        <p data-i18n="privacyText2">
           収集されたデータが外部サーバーに送信されることは一切ありません。本拡張機能は、インターネット経由でのデータ送信を行わない設計（Local-Only）となっています。
         </p>
       </section>
 
       <section>
-        <h2>3. サードパーティによる計測</h2>
-        <p>
+        <h2 data-i18n="privacyHeader3">3. サードパーティによる計測</h2>
+        <p data-i18n="privacyText3">
           本拡張機能および紹介用ウェブサイトでは、Google Analytics
           などのアクセス解析ツールや広告トラッキングなどは一切使用していません。
         </p>
       </section>
 
       <section>
-        <h2>4. データの削除</h2>
-        <p>
+        <h2 data-i18n="privacyHeader4">4. データの削除</h2>
+        <p data-i18n="privacyText4">
           利用者は、拡張機能をアンインストールすることで、ローカルに保存されたすべてのデータを削除することができます。
         </p>
       </section>
     </main>
 
     <footer>
-      <p>&copy; 2025 Issues-Solo. All rights reserved.</p>
+      <p data-i18n="copyright">&copy; 2025 Issues-Solo. All rights reserved.</p>
     </footer>
+    <script src="i18n.js"></script>
   </body>
 </html>

--- a/projects/web/usage.html
+++ b/projects/web/usage.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>使い方 - Issues-Solo</title>
+    <title>Issues-Solo</title>
     <style>
       :root {
         --md-sys-color-primary: #0061a4;
@@ -25,6 +25,25 @@
         align-items: center;
         padding: 1rem 2rem;
         border-bottom: 1px solid var(--md-sys-color-outline);
+      }
+      .lang-switcher {
+        display: flex;
+        gap: 0.5rem;
+        margin-left: 1.5rem;
+      }
+      .lang-switch {
+        cursor: pointer;
+        background: none;
+        border: 1px solid var(--md-sys-color-outline);
+        border-radius: 4px;
+        padding: 0.2rem 0.5rem;
+        font-size: 0.8rem;
+        color: var(--md-sys-color-on-surface);
+      }
+      .lang-switch.active {
+        background-color: var(--md-sys-color-primary);
+        color: var(--md-sys-color-on-primary);
+        border-color: var(--md-sys-color-primary);
       }
       .logo {
         display: flex;
@@ -64,46 +83,55 @@
   <body>
     <header>
       <a href="index.html" class="logo">Issues-Solo</a>
-      <nav>
-        <a href="index.html">トップ</a>
-        <a href="privacy.html">プライバシーポリシー</a>
+      <nav style="display: flex; align-items: center">
+        <a href="index.html" data-i18n="top">トップ</a>
+        <a href="privacy.html" data-i18n="privacy">プライバシーポリシー</a>
+        <div class="lang-switcher">
+          <button class="lang-switch" data-lang="en" data-i18n="langEn">
+            English
+          </button>
+          <button class="lang-switch" data-lang="ja" data-i18n="langJa">
+            日本語
+          </button>
+        </div>
       </nav>
     </header>
 
     <main>
-      <h1>Issues-Solo の使い方</h1>
+      <h1 data-i18n="usageGuide">Issues-Solo の使い方</h1>
 
       <section>
-        <h2>1. 履歴の自動記録</h2>
-        <p>
+        <h2 data-i18n="usageHeader1">1. 履歴の自動記録</h2>
+        <p data-i18n="usageText1">
           JIRA（atlassian.net）の課題ページを表示すると、自動的にその課題キーとタイトルが履歴として保存されます。
         </p>
       </section>
 
       <section>
-        <h2>2. サイドパネルを開く</h2>
-        <p>
+        <h2 data-i18n="usageHeader2">2. サイドパネルを開く</h2>
+        <p data-i18n="usageText2">
           ブラウザのツールバーにある拡張機能アイコンをクリック、またはサイドパネルから「Issues-Solo」を選択してパネルを開きます。
         </p>
       </section>
 
       <section>
-        <h2>3. 履歴の確認と移動</h2>
-        <p>
+        <h2 data-i18n="usageHeader3">3. 履歴の確認と移動</h2>
+        <p data-i18n="usageText3">
           サイドパネルに表示された履歴リストをクリックすると、該当するJIRA課題のタブに切り替わるか、新しいタブで開きます。
         </p>
       </section>
 
       <section>
-        <h2>4. 編集状態（書きかけ）の管理</h2>
-        <p>
+        <h2 data-i18n="usageHeader4">4. 編集状態（書きかけ）の管理</h2>
+        <p data-i18n="usageText4">
           JIRAのコメント欄や説明文を編集しているときに「編集中」の状態が検知されます。ブラウザを閉じたり再起動したりしても、その状態は保持され、サイドパネルから確認できます。
         </p>
       </section>
     </main>
 
     <footer>
-      <p>&copy; 2025 Issues-Solo. All rights reserved.</p>
+      <p data-i18n="copyright">&copy; 2025 Issues-Solo. All rights reserved.</p>
     </footer>
+    <script src="i18n.js"></script>
   </body>
 </html>

--- a/scripts/check_root_files.py
+++ b/scripts/check_root_files.py
@@ -80,7 +80,7 @@ def check_project_cleanliness():
         "LICENSE",
         "MaterialSymbolsOutlined.woff2",
     }
-    app_allowed_dirs = set()
+    app_allowed_dirs = {"_locales"}
     app_success = check_directory_cleanliness(
         app_dir, app_allowed_files, app_allowed_dirs
     )


### PR DESCRIPTION
Issues-Soloの多言語化（日本語・英語）を実施しました。
主な変更点は以下の通りです。

1. **Chrome拡張機能の多言語化**:
   - `_locales` ディレクトリを作成し、`en` と `ja` の `messages.json` を配置しました。
   - `manifest.json` を更新し、`default_locale` を `en` に設定、名称や説明を i18n プレースホルダーに置き換えました。
   - `sidepanel.html` および `sidepanel.js` を更新し、`data-i18n` 属性と `chrome.i18n.getMessage()` を用いてUIテキスト、ツールチップ、メッセージ類を多言語化しました。

2. **ランディングページの多言語化**:
   - `projects/web/i18n.js` を作成し、JavaScript による動的な言語切り替えロジックを実装しました。
   - ブラウザの言語設定の自動検出に加え、手動での切り替え（localStorage による永続化）をサポートしました。
   - `index.html`, `privacy.html`, `usage.html` を更新し、多言語対応の属性を付与しました。

3. **ドキュメントと情報の更新**:
   - `README.md` および `docs/spec.md` に日本語と英語を併記した免責事項を追加しました。
   - アプリのバージョンを `0.12.0` に繰り上げ、`package.json`, `package-lock.json`, `manifest.json`, `README.md` を同期させました。
   - 新規ディレクトリ `_locales` を許容するように `scripts/check_root_files.py` を更新しました。

すべての自動チェック（バージョン整合性、ルートディレクトリのクリーンネス）に合格していることを確認済みです。

---
*PR created automatically by Jules for task [2234721130701348144](https://jules.google.com/task/2234721130701348144) started by @masanori-satake*