### PR TITLE
Fix Build Error and Enhance Internationalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.12.0-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.12.1-blue)](manifest.json)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/build.py"

--- a/projects/app/_locales/en/messages.json
+++ b/projects/app/_locales/en/messages.json
@@ -201,9 +201,12 @@
     "message": "Hidden"
   },
   "other": {
-    "message": "other"
+    "message": "Other"
   },
   "close": {
     "message": "Close"
+  },
+  "creditsText": {
+    "message": "This project uses Material Design 3, an open-source design system by Google."
   }
 }

--- a/projects/app/_locales/ja/messages.json
+++ b/projects/app/_locales/ja/messages.json
@@ -205,5 +205,8 @@
   },
   "close": {
     "message": "閉じる"
+  },
+  "creditsText": {
+    "message": "このプロジェクトでは、Googleによるオープンソースのデザインシステムである Material Design 3 を使用しています。"
   }
 }

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -156,7 +156,9 @@
                       name="history-import-mode"
                       value="overwrite"
                     />
-                    <span data-i18n="importModeOverwrite">Overwrite</span></label
+                    <span data-i18n="importModeOverwrite"
+                      >Overwrite</span
+                    ></label
                   >
                 </div>
               </div>
@@ -168,7 +170,9 @@
           </section>
 
           <section id="data-section">
-            <h4 class="section-title" data-i18n="sectionSettings">Settings Data</h4>
+            <h4 class="section-title" data-i18n="sectionSettings">
+              Settings Data
+            </h4>
             <div class="data-management">
               <div class="management-buttons">
                 <button id="export-settings-btn" class="management-btn">
@@ -198,7 +202,9 @@
                       name="settings-import-mode"
                       value="overwrite"
                     />
-                    <span data-i18n="importModeOverwrite">Overwrite</span></label
+                    <span data-i18n="importModeOverwrite"
+                      >Overwrite</span
+                    ></label
                   >
                 </div>
               </div>
@@ -207,9 +213,7 @@
         </div>
         <div class="tab-content hidden" id="projects-tab">
           <section>
-            <h4 class="section-title" data-i18n="sectionProject">
-              Projects
-            </h4>
+            <h4 class="section-title" data-i18n="sectionProject">Projects</h4>
             <div class="project-list-container">
               <ul id="project-list"></ul>
             </div>
@@ -243,9 +247,7 @@
                 <span class="about-value" id="stat-projects">0</span>
               </div>
               <div class="stat-item">
-                <span class="about-label" data-i18n="statHistory"
-                  >History</span
-                >
+                <span class="about-label" data-i18n="statHistory">History</span>
                 <span class="about-value" id="stat-history">0</span>
               </div>
             </section>
@@ -258,7 +260,11 @@
             <section class="about-section">
               <div class="about-label">Issues-Solo</div>
               <p class="about-text" data-i18n="aboutDescription">
-                Issues-Solo is a privacy-focused Jira history tool. Data is stored in IndexedDB within your browser and is never sent externally. We maintain high transparency and security through dependency verification with GitHub Actions and continuous auditing with Google OSV-Scanner.
+                Issues-Solo is a privacy-focused Jira history tool. Data is
+                stored in IndexedDB within your browser and is never sent
+                externally. We maintain high transparency and security through
+                dependency verification with GitHub Actions and continuous
+                auditing with Google OSV-Scanner.
               </p>
             </section>
 
@@ -273,7 +279,9 @@
               <p class="about-text small italic">
                 <span data-i18n="disclaimerTitle">Disclaimer</span>
                 <span data-i18n="disclaimerText">
-                  This software is a personal open-source project and is provided "AS IS" without warranty of any kind. Use at your own risk, as per the MIT License.
+                  This software is a personal open-source project and is
+                  provided "AS IS" without warranty of any kind. Use at your own
+                  risk, as per the MIT License.
                 </span>
               </p>
             </section>
@@ -301,7 +309,9 @@
       <div class="dialog">
         <h3 data-i18n="addProjectTitle">Add Project Key</h3>
         <div class="input-field">
-          <label for="project-key-input" data-i18n="projectKey">Project Key</label>
+          <label for="project-key-input" data-i18n="projectKey"
+            >Project Key</label
+          >
           <input
             type="text"
             id="project-key-input"

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -156,9 +156,7 @@
                       name="history-import-mode"
                       value="overwrite"
                     />
-                    <span data-i18n="importModeOverwrite"
-                      >Overwrite</span
-                    ></label
+                    <span data-i18n="importModeOverwrite">Overwrite</span></label
                   >
                 </div>
               </div>
@@ -170,9 +168,7 @@
           </section>
 
           <section id="data-section">
-            <h4 class="section-title" data-i18n="sectionSettings">
-              Settings Data
-            </h4>
+            <h4 class="section-title" data-i18n="sectionSettings">Settings Data</h4>
             <div class="data-management">
               <div class="management-buttons">
                 <button id="export-settings-btn" class="management-btn">
@@ -202,9 +198,7 @@
                       name="settings-import-mode"
                       value="overwrite"
                     />
-                    <span data-i18n="importModeOverwrite"
-                      >Overwrite</span
-                    ></label
+                    <span data-i18n="importModeOverwrite">Overwrite</span></label
                   >
                 </div>
               </div>
@@ -213,7 +207,9 @@
         </div>
         <div class="tab-content hidden" id="projects-tab">
           <section>
-            <h4 class="section-title" data-i18n="sectionProject">Projects</h4>
+            <h4 class="section-title" data-i18n="sectionProject">
+              Projects
+            </h4>
             <div class="project-list-container">
               <ul id="project-list"></ul>
             </div>
@@ -247,7 +243,9 @@
                 <span class="about-value" id="stat-projects">0</span>
               </div>
               <div class="stat-item">
-                <span class="about-label" data-i18n="statHistory">History</span>
+                <span class="about-label" data-i18n="statHistory"
+                  >History</span
+                >
                 <span class="about-value" id="stat-history">0</span>
               </div>
             </section>
@@ -260,11 +258,7 @@
             <section class="about-section">
               <div class="about-label">Issues-Solo</div>
               <p class="about-text" data-i18n="aboutDescription">
-                Issues-Solo is a privacy-focused Jira history tool. Data is
-                stored in IndexedDB within your browser and is never sent
-                externally. We maintain high transparency and security through
-                dependency verification with GitHub Actions and continuous
-                auditing with Google OSV-Scanner.
+                Issues-Solo is a privacy-focused Jira history tool. Data is stored in IndexedDB within your browser and is never sent externally. We maintain high transparency and security through dependency verification with GitHub Actions and continuous auditing with Google OSV-Scanner.
               </p>
             </section>
 
@@ -279,9 +273,7 @@
               <p class="about-text small italic">
                 <span data-i18n="disclaimerTitle">Disclaimer</span>
                 <span data-i18n="disclaimerText">
-                  This software is a personal open-source project and is
-                  provided "AS IS" without warranty of any kind. Use at your own
-                  risk, as per the MIT License.
+                  This software is a personal open-source project and is provided "AS IS" without warranty of any kind. Use at your own risk, as per the MIT License.
                 </span>
               </p>
             </section>
@@ -309,9 +301,7 @@
       <div class="dialog">
         <h3 data-i18n="addProjectTitle">Add Project Key</h3>
         <div class="input-field">
-          <label for="project-key-input" data-i18n="projectKey"
-            >Project Key</label
-          >
+          <label for="project-key-input" data-i18n="projectKey">Project Key</label>
           <input
             type="text"
             id="project-key-input"

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ja">
+<html>
   <head>
     <meta charset="UTF-8" />
     <title>Issues-Solo</title>
@@ -61,13 +61,13 @@
 
     <main id="issue-list">
       <!-- 履歴がここに動的に生成される -->
-      <div class="loading" data-i18n="loading">履歴を読み込み中...</div>
+      <div class="loading" data-i18n="loading">Loading history...</div>
     </main>
 
     <div id="settings-panel" class="overlay hidden">
       <div class="settings-content">
         <div class="settings-header">
-          <div class="settings-title" data-i18n="settings">設定</div>
+          <div class="settings-title" data-i18n="settings">Settings</div>
           <button id="close-settings" class="icon-btn" data-i18n-title="close">
             <span class="material-symbols-outlined">close</span>
           </button>
@@ -94,7 +94,7 @@
         <div class="tab-content" id="general-tab">
           <section id="jira-site-section">
             <h4 class="section-title" data-i18n="sectionJiraSite">
-              Jira サイト
+              Jira Sites
             </h4>
             <div class="host-list-container">
               <ul id="host-list"></ul>
@@ -107,10 +107,10 @@
           </section>
 
           <section id="history-section">
-            <h4 class="section-title" data-i18n="sectionHistory">履歴</h4>
+            <h4 class="section-title" data-i18n="sectionHistory">History</h4>
             <div class="settings-item">
               <label for="max-history-range"
-                ><span data-i18n="maxHistoryCount">最大保持件数</span>:
+                ><span data-i18n="maxHistoryCount">Max history count</span>:
                 <span id="max-history-value">50</span></label
               >
               <input
@@ -131,15 +131,15 @@
               <div class="management-buttons">
                 <button id="export-history-btn" class="management-btn">
                   <span class="material-symbols-outlined">content_copy</span>
-                  <span data-i18n="copyExport">コピー (Export)</span>
+                  <span data-i18n="copyExport">Copy (Export)</span>
                 </button>
                 <button id="import-history-btn" class="management-btn">
                   <span class="material-symbols-outlined">content_paste</span>
-                  <span data-i18n="pasteImport">貼り付け (Import)</span>
+                  <span data-i18n="pasteImport">Paste (Import)</span>
                 </button>
               </div>
               <div class="import-mode-selector">
-                <label data-i18n="importSettings">インポート設定:</label>
+                <label data-i18n="importSettings">Import Settings:</label>
                 <div class="radio-group">
                   <label
                     ><input
@@ -148,7 +148,7 @@
                       value="add"
                       checked
                     />
-                    <span data-i18n="importModeAdd">追記</span></label
+                    <span data-i18n="importModeAdd">Add (Merge)</span></label
                   >
                   <label
                     ><input
@@ -156,32 +156,32 @@
                       name="history-import-mode"
                       value="overwrite"
                     />
-                    <span data-i18n="importModeOverwrite">上書き</span></label
+                    <span data-i18n="importModeOverwrite">Overwrite</span></label
                   >
                 </div>
               </div>
               <button id="clear-history-btn" class="management-btn danger">
                 <span class="material-symbols-outlined">delete_forever</span>
-                <span data-i18n="deleteAll">全削除</span>
+                <span data-i18n="deleteAll">Delete All</span>
               </button>
             </div>
           </section>
 
           <section id="data-section">
-            <h4 class="section-title" data-i18n="sectionSettings">設定</h4>
+            <h4 class="section-title" data-i18n="sectionSettings">Settings Data</h4>
             <div class="data-management">
               <div class="management-buttons">
                 <button id="export-settings-btn" class="management-btn">
                   <span class="material-symbols-outlined">content_copy</span>
-                  <span data-i18n="copyExport">コピー (Export)</span>
+                  <span data-i18n="copyExport">Copy (Export)</span>
                 </button>
                 <button id="import-settings-btn" class="management-btn">
                   <span class="material-symbols-outlined">content_paste</span>
-                  <span data-i18n="pasteImport">貼り付け (Import)</span>
+                  <span data-i18n="pasteImport">Paste (Import)</span>
                 </button>
               </div>
               <div class="import-mode-selector">
-                <label data-i18n="importSettings">インポート設定:</label>
+                <label data-i18n="importSettings">Import Settings:</label>
                 <div class="radio-group">
                   <label
                     ><input
@@ -190,7 +190,7 @@
                       value="add"
                       checked
                     />
-                    <span data-i18n="importModeAdd">追記</span></label
+                    <span data-i18n="importModeAdd">Add (Merge)</span></label
                   >
                   <label
                     ><input
@@ -198,7 +198,7 @@
                       name="settings-import-mode"
                       value="overwrite"
                     />
-                    <span data-i18n="importModeOverwrite">上書き</span></label
+                    <span data-i18n="importModeOverwrite">Overwrite</span></label
                   >
                 </div>
               </div>
@@ -208,7 +208,7 @@
         <div class="tab-content hidden" id="projects-tab">
           <section>
             <h4 class="section-title" data-i18n="sectionProject">
-              プロジェクト
+              Projects
             </h4>
             <div class="project-list-container">
               <ul id="project-list"></ul>
@@ -227,47 +227,43 @@
         <div class="tab-content hidden" id="about-tab">
           <div class="about-container">
             <section class="about-section">
-              <div class="about-label" data-i18n="version">バージョン</div>
+              <div class="about-label" data-i18n="version">Version</div>
               <div class="about-value" id="extension-version">v0.0.0</div>
             </section>
 
             <section class="about-section stats-row">
               <div class="stat-item">
-                <span class="about-label" data-i18n="statHosts">ホスト数</span>
+                <span class="about-label" data-i18n="statHosts">Hosts</span>
                 <span class="about-value" id="stat-hosts">0</span>
               </div>
               <div class="stat-item">
                 <span class="about-label" data-i18n="statProjects"
-                  >プロジェクト数</span
+                  >Projects</span
                 >
                 <span class="about-value" id="stat-projects">0</span>
               </div>
               <div class="stat-item">
                 <span class="about-label" data-i18n="statHistory"
-                  >履歴件数</span
+                  >History</span
                 >
                 <span class="about-value" id="stat-history">0</span>
               </div>
             </section>
 
             <section class="about-section">
-              <div class="about-label" data-i18n="developer">開発者</div>
+              <div class="about-label" data-i18n="developer">Developer</div>
               <div class="about-value">Masanori SATAKE</div>
             </section>
 
             <section class="about-section">
               <div class="about-label">Issues-Solo</div>
               <p class="about-text" data-i18n="aboutDescription">
-                Issues-Solo
-                は、プライバシー重視のJira履歴ツールです。データはブラウザ内の
-                IndexedDB に保存され、外部送信は一切行われません。GitHub Actions
-                による依存関係の検証と Google OSV-Scanner
-                による継続的な監査により、高い透明性と安全性を維持しています。
+                Issues-Solo is a privacy-focused Jira history tool. Data is stored in IndexedDB within your browser and is never sent externally. We maintain high transparency and security through dependency verification with GitHub Actions and continuous auditing with Google OSV-Scanner.
               </p>
             </section>
 
             <section class="about-section credits">
-              <p class="about-text small">
+              <p class="about-text small" data-i18n="creditsText">
                 This project uses Material Design 3, an open-source design
                 system by Google.
               </p>
@@ -275,9 +271,9 @@
 
             <section class="about-section disclaimer">
               <p class="about-text small italic">
-                <span data-i18n="disclaimerTitle">【免責事項】</span>
+                <span data-i18n="disclaimerTitle">Disclaimer</span>
                 <span data-i18n="disclaimerText">
-                  本ソフトウェアは個人開発によるオープンソースプロジェクトであり、無保証です。利用により生じたいかなる損害についても、開発者は一切の責任を負いません。自己責任でご利用ください。
+                  This software is a personal open-source project and is provided "AS IS" without warranty of any kind. Use at your own risk, as per the MIT License.
                 </span>
               </p>
             </section>
@@ -288,11 +284,11 @@
 
     <div id="confirm-dialog" class="overlay hidden">
       <div class="dialog">
-        <h3 id="confirm-title" data-i18n="confirm">確認</h3>
+        <h3 id="confirm-title" data-i18n="confirm">Confirm</h3>
         <p id="confirm-message"></p>
         <div class="dialog-actions">
           <button id="confirm-cancel" class="text-btn" data-i18n="cancel">
-            キャンセル
+            Cancel
           </button>
           <button id="confirm-ok" class="text-btn danger" data-i18n="ok">
             OK
@@ -303,21 +299,19 @@
 
     <div id="add-project-dialog" class="overlay hidden">
       <div class="dialog">
-        <h3 data-i18n="addProjectTitle">プロジェクトキーの追加</h3>
+        <h3 data-i18n="addProjectTitle">Add Project Key</h3>
         <div class="input-field">
-          <label for="project-key-input" data-i18n="projectKey"
-            >プロジェクトキー</label
-          >
+          <label for="project-key-input" data-i18n="projectKey">Project Key</label>
           <input
             type="text"
             id="project-key-input"
             data-i18n-placeholder="projectKeyPlaceholder"
-            placeholder="例: PROJ"
+            placeholder="e.g., PROJ"
           />
         </div>
         <div class="dialog-actions">
           <button id="cancel-add-project" class="text-btn" data-i18n="cancel">
-            キャンセル
+            Cancel
           </button>
           <button id="confirm-add-project" class="text-btn" data-i18n="ok">
             OK
@@ -328,31 +322,31 @@
 
     <div id="add-host-dialog" class="overlay hidden">
       <div class="dialog">
-        <h3 data-i18n="addHostTitle">Jiraホストの追加</h3>
+        <h3 data-i18n="addHostTitle">Add Jira Host</h3>
         <div class="input-field">
-          <label for="host-name" data-i18n="hostName">表示名</label>
+          <label for="host-name" data-i18n="hostName">Display Name</label>
           <input
             type="text"
             id="host-name"
             data-i18n-placeholder="hostNamePlaceholder"
-            placeholder="例: 社内Jira"
+            placeholder="e.g., Internal Jira"
           />
         </div>
         <div class="input-field">
-          <label for="host-url" data-i18n="hostUrl">URL / ドメイン</label>
+          <label for="host-url" data-i18n="hostUrl">URL / Domain</label>
           <input
             type="text"
             id="host-url"
             data-i18n-placeholder="hostUrlPlaceholder"
-            placeholder="例: jira.example.com"
+            placeholder="e.g., jira.example.com"
           />
         </div>
         <div class="dialog-actions">
           <button id="cancel-add-host" class="text-btn" data-i18n="cancel">
-            キャンセル
+            Cancel
           </button>
           <button id="confirm-add-host" class="text-btn" data-i18n="add">
-            追加
+            Add
           </button>
         </div>
       </div>

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -172,6 +172,12 @@ function compareStatus(a, b, direction) {
  * i18n対応: data-i18n属性を持つ要素のテキストを更新
  */
 function applyTranslations() {
+  // ブラウザの言語設定に合わせてhtmlのlang属性を更新
+  const uiLang = chrome.i18n.getUILanguage();
+  if (uiLang) {
+    document.documentElement.lang = uiLang.split("-")[0];
+  }
+
   const selectors = [
     "[data-i18n]",
     "[data-i18n-title]",

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,6 +1,7 @@
 import json
 import zipfile
 import os
+import glob
 
 
 def build_extension():
@@ -30,7 +31,7 @@ def build_extension():
             for root, dirs, files in os.walk(app_dir):
                 for file in files:
                     # Skip hidden files
-                    if file.startswith("."):
+                    if file.startswith('.'):
                         continue
 
                     file_path = os.path.join(root, file)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -25,23 +25,20 @@ def build_extension():
 
         # 3. Define files to include
         app_dir = os.path.join("projects", "app")
-        patterns = ["manifest.json", "*.js", "*.html", "*.css", "LICENSE", "*.woff2"]
 
-        files_to_zip = []
-        for pattern in patterns:
-            files_to_zip.extend(glob.glob(os.path.join(app_dir, pattern)))
-
-        # Remove duplicates and sort
-        files_to_zip = sorted(list(set(files_to_zip)))
-
-        # 4. Create the zip file
         print(f"Building Issues-Solo version {version}...")
         with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
-            for file_path in files_to_zip:
-                # Store in zip without projects/app prefix
-                arcname = os.path.basename(file_path)
-                print(f"  Adding: {file_path} as {arcname}")
-                zipf.write(file_path, arcname)
+            for root, dirs, files in os.walk(app_dir):
+                for file in files:
+                    # Skip hidden files
+                    if file.startswith('.'):
+                        continue
+
+                    file_path = os.path.join(root, file)
+                    # Store in zip without projects/app prefix
+                    arcname = os.path.relpath(file_path, app_dir)
+                    print(f"  Adding: {file_path} as {arcname}")
+                    zipf.write(file_path, arcname)
 
         print(f"Successfully built {zip_filename}")
         return True

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,7 +1,6 @@
 import json
 import zipfile
 import os
-import glob
 
 
 def build_extension():
@@ -31,7 +30,7 @@ def build_extension():
             for root, dirs, files in os.walk(app_dir):
                 for file in files:
                     # Skip hidden files
-                    if file.startswith('.'):
+                    if file.startswith("."):
                         continue
 
                     file_path = os.path.join(root, file)


### PR DESCRIPTION
Fixed the build script to include the `_locales` directory, resolving the installation error. Improved internationalization by dynamically setting the document language and replacing all hardcoded Japanese strings in the HTML with `data-i18n` attributes. Updated the "other" group name to "その他" (Japanese) and "Other" (English) as requested.

---
*PR created automatically by Jules for task [14604987817142340460](https://jules.google.com/task/14604987817142340460) started by @masanori-satake*