### PR TITLE
Update last accessed time on tab focus and visibility change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.12.1-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.12.2-blue)](manifest.json)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/build.py"

--- a/projects/app/content.js
+++ b/projects/app/content.js
@@ -364,6 +364,16 @@
   // 編集状態の監視
   document.addEventListener("focusin", startEditing);
 
+  // タブの表示状態やウィンドウのフォーカスを監視して、最終表示時刻を更新する
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      notifyChange();
+    }
+  };
+
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+  window.addEventListener("focus", handleVisibilityChange);
+
   // キー操作による編集終了（EnterやEscape）の検知
   document.addEventListener(
     "keydown",

--- a/projects/app/content.js
+++ b/projects/app/content.js
@@ -236,11 +236,14 @@
     return false;
   };
 
+  let lastNotifyTime = 0;
+
   /**
    * 変更をバックグラウンドに通知する
    */
   const notifyChange = (isEditing = null) => {
     const issueKey = getIssueKey();
+    lastNotifyTime = Date.now();
     if (!issueKey) {
       // 課題ページでない場合は、タブの関連付けを解除する
       chrome.runtime.sendMessage({ type: "CLEAR_TAB_ASSOCIATION" });
@@ -366,8 +369,12 @@
 
   // タブの表示状態やウィンドウのフォーカスを監視して、最終表示時刻を更新する
   const handleVisibilityChange = () => {
-    if (document.visibilityState === "visible") {
-      notifyChange();
+    if (document.visibilityState === "visible" && getIssueKey()) {
+      const now = Date.now();
+      // 短時間の重複通知（focusとvisibilitychangeの同時発生など）を抑制
+      if (now - lastNotifyTime > 1000) {
+        notifyChange();
+      }
     }
   };
 

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [


### PR DESCRIPTION
Added event listeners for `visibilitychange` and `focus` in `content.js` to ensure the "Last Accessed Time" is updated when a user switches to a Jira issue tab or returns focus to the browser window. This fixes the issue where the side panel sort order would not reflect the most recently viewed issue if the tab was already open. Also bumped version to 0.12.2.

---
*PR created automatically by Jules for task [8108088164918384554](https://jules.google.com/task/8108088164918384554) started by @masanori-satake*