### PR TITLE
Add GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: "Bug Report / 不具合報告"
+description: "Report a bug to help us improve. / 不具合を報告して改善に協力してください。"
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ご報告ありがとうございます！不具合の特定をスムーズに行うため、以下の情報の提供をお願いします。
+        Thank you for reporting! Please provide the following information to help us identify the issue.
+  - type: dropdown
+    id: target-app
+    attributes:
+      label: "Target Application / 対象アプリ"
+      options:
+        - "Issues-Solo (Main Extension)"
+        - "Landing Page (Official Website)"
+        - "Other / その他"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: "Version / バージョン"
+      description: "Check in 'Settings > About' / 「設定 > About」から確認できます"
+      placeholder: "v0.12.2"
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: "OS & Browser / OSとブラウザ"
+      placeholder: "Windows 11 / Chrome 120"
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: "Reproduction Steps / 再現手順"
+      description: "How did it happen? / 何をしたら発生しましたか？"
+      placeholder: |
+        1. Click on ...
+        2. Change setting to ...
+        3. The issue appears ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Expected Behavior / 期待される挙動"
+      description: "What did you expect to happen? / 本来どうなるべきでしたか？"
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: "Actual Behavior / 実際の挙動"
+      description: "What actually happened? / 実際に何が起きましたか？"
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: "### Diagnostic Information / 調査用情報"
+  - type: input
+    id: stats
+    attributes:
+      label: "App Statistics / アプリの状態"
+      description: "Found in 'Settings > About' / 「設定 > About」に表示されています"
+      placeholder: "Issues: 50, Hosts: 2, Projects: 5"
+  - type: dropdown
+    id: lang-setting
+    attributes:
+      label: "Language Setting / 使用言語設定"
+      options:
+        - "Auto (Browser) / 自動"
+        - "English"
+        - "Japanese / 日本語"
+        - "Other / その他"
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: "Additional Context / 補足情報"
+      description: "Screenshots or data files. **Please redact any personal info before attaching.** / スクリーンショットやデータファイル。**個人情報が含まれる場合は、必ず伏せた上で添付してください。**"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,8 +13,8 @@ body:
     attributes:
       label: "Target Application / 対象アプリ"
       options:
-        - "Issues-Solo (Main Extension)"
-        - "Landing Page (Official Website)"
+        - "Issues-Solo (Extension / 拡張機能)"
+        - "Official Website / 公式サイト (Landing Page)"
         - "Other / その他"
     validations:
       required: true
@@ -72,8 +72,8 @@ body:
     attributes:
       label: "Language Setting / 使用言語設定"
       options:
-        - "Auto (Browser) / 自動"
-        - "English"
+        - "Auto (Browser) / 自動 (ブラウザ設定)"
+        - "English / 英語"
         - "Japanese / 日本語"
         - "Other / その他"
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,8 +13,8 @@ body:
     attributes:
       label: "Target Application / 対象アプリ"
       options:
-        - "Issues-Solo (Main Extension)"
-        - "Landing Page (Official Website)"
+        - "Issues-Solo (Extension / 拡張機能)"
+        - "Official Website / 公式サイト (Landing Page)"
         - "Project-wide / プロジェクト全体"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: "Feature Request / 機能・改善リクエスト"
+description: "Suggest an idea for this project. / 新機能や改善のアイデアを提案してください。"
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        アイデアを共有していただきありがとうございます！
+        Thank you for sharing your ideas!
+  - type: dropdown
+    id: target-app
+    attributes:
+      label: "Target Application / 対象アプリ"
+      options:
+        - "Issues-Solo (Main Extension)"
+        - "Landing Page (Official Website)"
+        - "Project-wide / プロジェクト全体"
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: "Feature Category / 機能カテゴリ"
+      options:
+        - "Core Logic / 履歴記録・抽出ロジック"
+        - "UI / Design / UIデザイン"
+        - "Import / Export / インポート・エクスポート"
+        - "Host / Project Settings / サイト・プロジェクト設定"
+        - "Localization / 多言語対応"
+        - "New Feature Idea / 既存にない新機能"
+        - "Other / その他"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: "Problem Description / 解決したい課題"
+      description: "Is your feature request related to a problem? / 何か困っていることや、不便に感じていることはありますか？"
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: "Proposed Solution / 提案内容"
+      description: "Describe the solution you'd like. / どのような機能や改善を希望しますか？"
+    validations:
+      required: true
+  - type: textarea
+    id: alternative
+    attributes:
+      label: "Alternatives Considered / 代替案"
+      description: "Any alternative solutions or features you've considered. / 他に検討した方法があれば教えてください。"
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: "Additional Context / 補足情報"
+      description: "Add any other context or screenshots about the feature request here. / その他、参考になる情報やイメージ図があればこちらに。"


### PR DESCRIPTION
Added structured GitHub Issue Form templates for bug reports and feature requests.
The templates are bilingual (EN/JA) and tailored specifically for the Issues-Solo project,
incorporating user feedback on application targets and feature categories.

---
*PR created automatically by Jules for task [13915591994510709265](https://jules.google.com/task/13915591994510709265) started by @masanori-satake*