### PR TITLE
PNGアイコン生成機能の導入とManifestへの適用

### DIFF
--- a/.github/workflows/release_extension_packages.yml
+++ b/.github/workflows/release_extension_packages.yml
@@ -28,8 +28,42 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Install Playwright Dependencies (if cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Install Python Playwright
+        run: pip install playwright
+
       - name: Build packages
-        run: python3 scripts/build.py
+        run: npm run build
 
       - name: Create GitHub Release and Upload Assets
         uses: softprops/action-gh-release@v2

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ playwright/.cache/
 # Production
 releases/
 *.zip
+projects/app/assets/icon*.png
 
 # Misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "version": "0.12.2",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
-    "build": "python3 scripts/build.py"
+    "build": "python3 scripts/generate_png_icons.py && python3 scripts/check_version.py && python3 scripts/verify_project_policies.py && python3 scripts/build.py"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.49.0"
+    "@playwright/test": "^1.49.0",
+    "playwright": "^1.49.0"
   }
 }

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -34,6 +34,18 @@
     "default_path": "sidepanel.html"
   },
   "action": {
-    "default_title": "__MSG_actionTitle__"
+    "default_title": "__MSG_actionTitle__",
+    "default_icon": {
+      "16": "assets/icon16.png",
+      "32": "assets/icon32.png",
+      "48": "assets/icon48.png",
+      "128": "assets/icon128.png"
+    }
+  },
+  "icons": {
+    "16": "assets/icon16.png",
+    "32": "assets/icon32.png",
+    "48": "assets/icon48.png",
+    "128": "assets/icon128.png"
   }
 }

--- a/scripts/check_root_files.py
+++ b/scripts/check_root_files.py
@@ -80,7 +80,7 @@ def check_project_cleanliness():
         "LICENSE",
         "MaterialSymbolsOutlined.woff2",
     }
-    app_allowed_dirs = {"_locales"}
+    app_allowed_dirs = {"_locales", "assets"}
     app_success = check_directory_cleanliness(
         app_dir, app_allowed_files, app_allowed_dirs
     )

--- a/scripts/generate_png_icons.py
+++ b/scripts/generate_png_icons.py
@@ -2,48 +2,53 @@ import os
 import sys
 import re
 
-
 def generate_icons(output_dir=None, bg_color=None):
-    # Base path for the source SVG
-    svg_path = os.path.join(os.getcwd(), "projects/app/assets/icon.svg")
+    # Use script-relative paths for reliability
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.abspath(os.path.join(script_dir, ".."))
+
+    svg_path = os.path.join(project_root, 'projects/app/assets/icon.svg')
 
     # Default output directory
     if output_dir is None:
-        output_dir = os.path.join(os.getcwd(), "projects/app/assets")
+        output_dir = os.path.join(project_root, 'projects/app/assets')
+    else:
+        output_dir = os.path.abspath(output_dir)
 
     if not os.path.exists(svg_path):
         print(f"Error: {svg_path} not found.")
         return False
 
-    with open(svg_path, "r", encoding="utf-8") as f:
+    with open(svg_path, 'r', encoding='utf-8') as f:
         svg_content = f.read()
 
     if bg_color:
-        # Improved replacement logic using regex to identify the background rect (512x512)
-        pattern = (
-            r'(<rect\s+[^>]*width="512"\s+[^>]*height="512"\s+[^>]*fill=")([^"]+)(")'
-        )
+        # Flexible regex for <rect width="512" height="512" ... fill="...">
+        # Matches regardless of attribute order and quotes
+        pattern = r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'][^>]*width=["\']512["\'][^>]*height=["\']512["\'])|' \
+                  r'(<rect\s+[^>]*width=["\']512["\'][^>]*height=["\']512["\'][^>]*fill=["\'])([^"\']+)(["\'])'
+
+        def replace_fill(match):
+            if match.group(1): # fill comes before width/height
+                return f"{match.group(1)}{bg_color}{match.group(3)}"
+            else: # fill comes after width/height
+                return f"{match.group(4)}{bg_color}{match.group(6)}"
+
         if re.search(pattern, svg_content):
-            svg_content = re.sub(pattern, rf"\1{bg_color}\3", svg_content)
+            svg_content = re.sub(pattern, replace_fill, svg_content)
             print(f"Background color dynamically changed to {bg_color}")
         else:
-            # Fallback if the strict pattern doesn't match
-            svg_content = re.sub(
-                r'(<rect\s+[^>]*fill=")([^"]+)(")',
-                rf"\1{bg_color}\3",
-                svg_content,
-                count=1,
-            )
-            print(f"Background color changed to {bg_color} (using fallback regex)")
+            # Fallback: find the first rect with a fill attribute
+            fallback_pattern = r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'])'
+            if re.search(fallback_pattern, svg_content):
+                svg_content = re.sub(fallback_pattern, rf'\1{bg_color}\3', svg_content, count=1)
+                print(f"Background color changed to {bg_color} (using fallback regex)")
 
     try:
         from playwright.sync_api import sync_playwright
-
         print("Playwright found. Generating icons...")
     except ImportError:
-        print(
-            "Error: No module named 'playwright'. Please install it to generate extension icons."
-        )
+        print("Error: No module named 'playwright'. Please install it to generate extension icons.")
         return False
 
     if not os.path.exists(output_dir):
@@ -54,30 +59,42 @@ def generate_icons(output_dir=None, bg_color=None):
             browser = p.chromium.launch()
         except Exception as e:
             print(f"Error: Failed to launch browser: {e}")
+            print("Hint: Try running 'playwright install chromium' or 'npx playwright install chromium'.")
             return False
 
         context = browser.new_context(
-            viewport={"width": 512, "height": 512}, device_scale_factor=1
+            viewport={'width': 512, 'height': 512},
+            device_scale_factor=1
         )
         page = context.new_page()
 
-        page.set_content(f"""
+        # Use a template literal to safely inject SVG content that might contain braces
+        page.set_content("""
+            <!DOCTYPE html>
+            <html>
+            <head>
             <style>
-              body, html {{ margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; }}
-              svg {{ width: 100%; height: 100%; display: block; }}
+              body, html { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: transparent; }
+              svg { width: 100%; height: 100%; display: block; }
             </style>
-            {svg_content}
+            </head>
+            <body>
+            """ + svg_content + """
+            </body>
+            </html>
         """)
 
         for size in [16, 32, 48, 128]:
             output_path = os.path.join(output_dir, f"icon{size}.png")
             print(f"Generating {size}x{size} icon: {output_path}")
 
-            page.set_viewport_size({"width": size, "height": size})
+            page.set_viewport_size({'width': size, 'height': size})
+            # Ensure SVG has time to render if it has transitions or complex filters
+            page.wait_for_timeout(100)
             page.screenshot(
                 path=output_path,
                 omit_background=True,
-                clip={"x": 0, "y": 0, "width": size, "height": size},
+                clip={'x': 0, 'y': 0, 'width': size, 'height': size}
             )
 
         browser.close()
@@ -85,9 +102,7 @@ def generate_icons(output_dir=None, bg_color=None):
     print(f"Icon generation complete in {output_dir}")
     return True
 
-
 if __name__ == "__main__":
-    # Support optional command line arguments: [output_dir] [bg_color]
     target_dir = sys.argv[1] if len(sys.argv) > 1 else None
     color = sys.argv[2] if len(sys.argv) > 2 else None
 

--- a/scripts/generate_png_icons.py
+++ b/scripts/generate_png_icons.py
@@ -2,48 +2,37 @@ import os
 import sys
 import re
 
-
 def generate_icons(output_dir=None, bg_color=None):
     # Base path for the source SVG
-    svg_path = os.path.join(os.getcwd(), "projects/app/assets/icon.svg")
+    svg_path = os.path.join(os.getcwd(), 'projects/app/assets/icon.svg')
 
     # Default output directory
     if output_dir is None:
-        output_dir = os.path.join(os.getcwd(), "projects/app/assets")
+        output_dir = os.path.join(os.getcwd(), 'projects/app/assets')
 
     if not os.path.exists(svg_path):
         print(f"Error: {svg_path} not found.")
         return False
 
-    with open(svg_path, "r", encoding="utf-8") as f:
+    with open(svg_path, 'r', encoding='utf-8') as f:
         svg_content = f.read()
 
     if bg_color:
         # Improved replacement logic using regex to identify the background rect (512x512)
-        pattern = (
-            r'(<rect\s+[^>]*width="512"\s+[^>]*height="512"\s+[^>]*fill=")([^"]+)(")'
-        )
+        pattern = r'(<rect\s+[^>]*width="512"\s+[^>]*height="512"\s+[^>]*fill=")([^"]+)(")'
         if re.search(pattern, svg_content):
-            svg_content = re.sub(pattern, rf"\1{bg_color}\3", svg_content)
+            svg_content = re.sub(pattern, rf'\1{bg_color}\3', svg_content)
             print(f"Background color dynamically changed to {bg_color}")
         else:
             # Fallback if the strict pattern doesn't match
-            svg_content = re.sub(
-                r'(<rect\s+[^>]*fill=")([^"]+)(")',
-                rf"\1{bg_color}\3",
-                svg_content,
-                count=1,
-            )
+            svg_content = re.sub(r'(<rect\s+[^>]*fill=")([^"]+)(")', rf'\1{bg_color}\3', svg_content, count=1)
             print(f"Background color changed to {bg_color} (using fallback regex)")
 
     try:
         from playwright.sync_api import sync_playwright
-
         print("Playwright found. Generating icons...")
     except ImportError:
-        print(
-            "Error: No module named 'playwright'. Please install it to generate extension icons."
-        )
+        print("Error: No module named 'playwright'. Please install it to generate extension icons.")
         return False
 
     if not os.path.exists(output_dir):
@@ -57,7 +46,8 @@ def generate_icons(output_dir=None, bg_color=None):
             return False
 
         context = browser.new_context(
-            viewport={"width": 512, "height": 512}, device_scale_factor=1
+            viewport={'width': 512, 'height': 512},
+            device_scale_factor=1
         )
         page = context.new_page()
 
@@ -73,18 +63,17 @@ def generate_icons(output_dir=None, bg_color=None):
             output_path = os.path.join(output_dir, f"icon{size}.png")
             print(f"Generating {size}x{size} icon: {output_path}")
 
-            page.set_viewport_size({"width": size, "height": size})
+            page.set_viewport_size({'width': size, 'height': size})
             page.screenshot(
                 path=output_path,
                 omit_background=True,
-                clip={"x": 0, "y": 0, "width": size, "height": size},
+                clip={'x': 0, 'y': 0, 'width': size, 'height': size}
             )
 
         browser.close()
 
     print(f"Icon generation complete in {output_dir}")
     return True
-
 
 if __name__ == "__main__":
     # Support optional command line arguments: [output_dir] [bg_color]

--- a/scripts/generate_png_icons.py
+++ b/scripts/generate_png_icons.py
@@ -2,17 +2,15 @@ import os
 import sys
 import re
 
-
 def generate_icons(output_dir=None, bg_color=None):
     # Use script-relative paths for reliability
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    project_root = os.path.abspath(os.path.join(script_dir, ".."))
-
-    svg_path = os.path.join(project_root, "projects/app/assets/icon.svg")
+    root_dir = os.path.dirname(script_dir)
+    svg_path = os.path.join(root_dir, "projects/app/assets/icon.svg")
 
     # Default output directory
     if output_dir is None:
-        output_dir = os.path.join(project_root, "projects/app/assets")
+        output_dir = os.path.join(root_dir, "projects/app/assets")
     else:
         output_dir = os.path.abspath(output_dir)
 
@@ -20,21 +18,19 @@ def generate_icons(output_dir=None, bg_color=None):
         print(f"Error: {svg_path} not found.")
         return False
 
-    with open(svg_path, "r", encoding="utf-8") as f:
+    with open(svg_path, 'r', encoding='utf-8') as f:
         svg_content = f.read()
 
     if bg_color:
         # Flexible regex for <rect width="512" height="512" ... fill="...">
         # Matches regardless of attribute order and quotes
-        pattern = (
-            r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'][^>]*width=["\']512["\'][^>]*height=["\']512["\'])|'
-            r'(<rect\s+[^>]*width=["\']512["\'][^>]*height=["\']512["\'][^>]*fill=["\'])([^"\']+)(["\'])'
-        )
+        pattern = r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'][^>]*width=["\']512["\'][^>]*height=["\']512["\'])|' \
+                  r'(<rect\s+[^>]*width=["\']512["\'][^>]*height=["\']512["\'][^>]*fill=["\'])([^"\']+)(["\'])'
 
         def replace_fill(match):
-            if match.group(1):  # fill comes before width/height
+            if match.group(1): # fill comes before width/height
                 return f"{match.group(1)}{bg_color}{match.group(3)}"
-            else:  # fill comes after width/height
+            else: # fill comes after width/height
                 return f"{match.group(4)}{bg_color}{match.group(6)}"
 
         if re.search(pattern, svg_content):
@@ -44,19 +40,14 @@ def generate_icons(output_dir=None, bg_color=None):
             # Fallback: find the first rect with a fill attribute
             fallback_pattern = r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'])'
             if re.search(fallback_pattern, svg_content):
-                svg_content = re.sub(
-                    fallback_pattern, rf"\1{bg_color}\3", svg_content, count=1
-                )
+                svg_content = re.sub(fallback_pattern, rf'\1{bg_color}\3', svg_content, count=1)
                 print(f"Background color changed to {bg_color} (using fallback regex)")
 
     try:
         from playwright.sync_api import sync_playwright
-
         print("Playwright found. Generating icons...")
     except ImportError:
-        print(
-            "Error: No module named 'playwright'. Please install it to generate extension icons."
-        )
+        print("Error: No module named 'playwright'. Please install it to generate extension icons.")
         return False
 
     if not os.path.exists(output_dir):
@@ -67,19 +58,17 @@ def generate_icons(output_dir=None, bg_color=None):
             browser = p.chromium.launch()
         except Exception as e:
             print(f"Error: Failed to launch browser: {e}")
-            print(
-                "Hint: Try running 'playwright install chromium' or 'npx playwright install chromium'."
-            )
+            print("Hint: Try running 'playwright install chromium' or 'npx playwright install chromium'.")
             return False
 
         context = browser.new_context(
-            viewport={"width": 512, "height": 512}, device_scale_factor=1
+            viewport={'width': 512, 'height': 512},
+            device_scale_factor=1
         )
         page = context.new_page()
 
         # Use a template literal to safely inject SVG content that might contain braces
-        page.set_content(
-            """
+        page.set_content("""
             <!DOCTYPE html>
             <html>
             <head>
@@ -89,32 +78,28 @@ def generate_icons(output_dir=None, bg_color=None):
             </style>
             </head>
             <body>
-            """
-            + svg_content
-            + """
+            """ + svg_content + """
             </body>
             </html>
-        """
-        )
+        """)
 
         for size in [16, 32, 48, 128]:
             output_path = os.path.join(output_dir, f"icon{size}.png")
             print(f"Generating {size}x{size} icon: {output_path}")
 
-            page.set_viewport_size({"width": size, "height": size})
+            page.set_viewport_size({'width': size, 'height': size})
             # Ensure SVG has time to render if it has transitions or complex filters
             page.wait_for_timeout(100)
             page.screenshot(
                 path=output_path,
                 omit_background=True,
-                clip={"x": 0, "y": 0, "width": size, "height": size},
+                clip={'x': 0, 'y': 0, 'width': size, 'height': size}
             )
 
         browser.close()
 
     print(f"Icon generation complete in {output_dir}")
     return True
-
 
 if __name__ == "__main__":
     target_dir = sys.argv[1] if len(sys.argv) > 1 else None

--- a/scripts/generate_png_icons.py
+++ b/scripts/generate_png_icons.py
@@ -2,6 +2,7 @@ import os
 import sys
 import re
 
+
 def generate_icons(output_dir=None, bg_color=None):
     # Use script-relative paths for reliability
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -18,7 +19,7 @@ def generate_icons(output_dir=None, bg_color=None):
         print(f"Error: {svg_path} not found.")
         return False
 
-    with open(svg_path, 'r', encoding='utf-8') as f:
+    with open(svg_path, "r", encoding="utf-8") as f:
         svg_content = f.read()
 
     if bg_color:
@@ -40,12 +41,16 @@ def generate_icons(output_dir=None, bg_color=None):
 
             if found:
                 svg_content = ET.tostring(root, encoding="unicode")
-                print(f"Background color dynamically changed to {bg_color} using XML parser")
+                print(
+                    f"Background color dynamically changed to {bg_color} using XML parser"
+                )
             else:
-                print("Warning: Background rect (512x512) not found. Using regex fallback.")
+                print(
+                    "Warning: Background rect (512x512) not found. Using regex fallback."
+                )
                 raise ValueError("Background rect not found")
 
-        except Exception as e:
+        except Exception:
             # Fallback to regex if XML parsing fails or target not found
             pattern = (
                 r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'][^>]*width=["\']512["\'][^>]*height=["\']512["\'])|'
@@ -67,13 +72,18 @@ def generate_icons(output_dir=None, bg_color=None):
                     svg_content = re.sub(
                         fallback_pattern, rf"\1{bg_color}\3", svg_content, count=1
                     )
-                    print(f"Background color changed to {bg_color} (first rect fallback)")
+                    print(
+                        f"Background color changed to {bg_color} (first rect fallback)"
+                    )
 
     try:
         from playwright.sync_api import sync_playwright
+
         print("Playwright found. Generating icons...")
     except ImportError:
-        print("Error: No module named 'playwright'. Please install it to generate extension icons.")
+        print(
+            "Error: No module named 'playwright'. Please install it to generate extension icons."
+        )
         return False
 
     if not os.path.exists(output_dir):
@@ -84,17 +94,19 @@ def generate_icons(output_dir=None, bg_color=None):
             browser = p.chromium.launch()
         except Exception as e:
             print(f"Error: Failed to launch browser: {e}")
-            print("Hint: Try running 'playwright install chromium' or 'npx playwright install chromium'.")
+            print(
+                "Hint: Try running 'playwright install chromium' or 'npx playwright install chromium'."
+            )
             return False
 
         context = browser.new_context(
-            viewport={'width': 512, 'height': 512},
-            device_scale_factor=1
+            viewport={"width": 512, "height": 512}, device_scale_factor=1
         )
         page = context.new_page()
 
         # Use a template literal to safely inject SVG content that might contain braces
-        page.set_content("""
+        page.set_content(
+            """
             <!DOCTYPE html>
             <html>
             <head>
@@ -104,28 +116,32 @@ def generate_icons(output_dir=None, bg_color=None):
             </style>
             </head>
             <body>
-            """ + svg_content + """
+            """
+            + svg_content
+            + """
             </body>
             </html>
-        """)
+        """
+        )
 
         for size in [16, 32, 48, 128]:
             output_path = os.path.join(output_dir, f"icon{size}.png")
             print(f"Generating {size}x{size} icon: {output_path}")
 
-            page.set_viewport_size({'width': size, 'height': size})
+            page.set_viewport_size({"width": size, "height": size})
             # Ensure SVG has time to render if it has transitions or complex filters
             page.wait_for_timeout(100)
             page.screenshot(
                 path=output_path,
                 omit_background=True,
-                clip={'x': 0, 'y': 0, 'width': size, 'height': size}
+                clip={"x": 0, "y": 0, "width": size, "height": size},
             )
 
         browser.close()
 
     print(f"Icon generation complete in {output_dir}")
     return True
+
 
 if __name__ == "__main__":
     target_dir = sys.argv[1] if len(sys.argv) > 1 else None

--- a/scripts/generate_png_icons.py
+++ b/scripts/generate_png_icons.py
@@ -2,6 +2,7 @@ import os
 import sys
 import re
 
+
 def generate_icons(output_dir=None, bg_color=None):
     # Use script-relative paths for reliability
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -18,19 +19,21 @@ def generate_icons(output_dir=None, bg_color=None):
         print(f"Error: {svg_path} not found.")
         return False
 
-    with open(svg_path, 'r', encoding='utf-8') as f:
+    with open(svg_path, "r", encoding="utf-8") as f:
         svg_content = f.read()
 
     if bg_color:
         # Flexible regex for <rect width="512" height="512" ... fill="...">
         # Matches regardless of attribute order and quotes
-        pattern = r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'][^>]*width=["\']512["\'][^>]*height=["\']512["\'])|' \
-                  r'(<rect\s+[^>]*width=["\']512["\'][^>]*height=["\']512["\'][^>]*fill=["\'])([^"\']+)(["\'])'
+        pattern = (
+            r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'][^>]*width=["\']512["\'][^>]*height=["\']512["\'])|'
+            r'(<rect\s+[^>]*width=["\']512["\'][^>]*height=["\']512["\'][^>]*fill=["\'])([^"\']+)(["\'])'
+        )
 
         def replace_fill(match):
-            if match.group(1): # fill comes before width/height
+            if match.group(1):  # fill comes before width/height
                 return f"{match.group(1)}{bg_color}{match.group(3)}"
-            else: # fill comes after width/height
+            else:  # fill comes after width/height
                 return f"{match.group(4)}{bg_color}{match.group(6)}"
 
         if re.search(pattern, svg_content):
@@ -40,14 +43,19 @@ def generate_icons(output_dir=None, bg_color=None):
             # Fallback: find the first rect with a fill attribute
             fallback_pattern = r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'])'
             if re.search(fallback_pattern, svg_content):
-                svg_content = re.sub(fallback_pattern, rf'\1{bg_color}\3', svg_content, count=1)
+                svg_content = re.sub(
+                    fallback_pattern, rf"\1{bg_color}\3", svg_content, count=1
+                )
                 print(f"Background color changed to {bg_color} (using fallback regex)")
 
     try:
         from playwright.sync_api import sync_playwright
+
         print("Playwright found. Generating icons...")
     except ImportError:
-        print("Error: No module named 'playwright'. Please install it to generate extension icons.")
+        print(
+            "Error: No module named 'playwright'. Please install it to generate extension icons."
+        )
         return False
 
     if not os.path.exists(output_dir):
@@ -58,17 +66,19 @@ def generate_icons(output_dir=None, bg_color=None):
             browser = p.chromium.launch()
         except Exception as e:
             print(f"Error: Failed to launch browser: {e}")
-            print("Hint: Try running 'playwright install chromium' or 'npx playwright install chromium'.")
+            print(
+                "Hint: Try running 'playwright install chromium' or 'npx playwright install chromium'."
+            )
             return False
 
         context = browser.new_context(
-            viewport={'width': 512, 'height': 512},
-            device_scale_factor=1
+            viewport={"width": 512, "height": 512}, device_scale_factor=1
         )
         page = context.new_page()
 
         # Use a template literal to safely inject SVG content that might contain braces
-        page.set_content("""
+        page.set_content(
+            """
             <!DOCTYPE html>
             <html>
             <head>
@@ -78,28 +88,32 @@ def generate_icons(output_dir=None, bg_color=None):
             </style>
             </head>
             <body>
-            """ + svg_content + """
+            """
+            + svg_content
+            + """
             </body>
             </html>
-        """)
+        """
+        )
 
         for size in [16, 32, 48, 128]:
             output_path = os.path.join(output_dir, f"icon{size}.png")
             print(f"Generating {size}x{size} icon: {output_path}")
 
-            page.set_viewport_size({'width': size, 'height': size})
+            page.set_viewport_size({"width": size, "height": size})
             # Ensure SVG has time to render if it has transitions or complex filters
             page.wait_for_timeout(100)
             page.screenshot(
                 path=output_path,
                 omit_background=True,
-                clip={'x': 0, 'y': 0, 'width': size, 'height': size}
+                clip={"x": 0, "y": 0, "width": size, "height": size},
             )
 
         browser.close()
 
     print(f"Icon generation complete in {output_dir}")
     return True
+
 
 if __name__ == "__main__":
     target_dir = sys.argv[1] if len(sys.argv) > 1 else None

--- a/scripts/generate_png_icons.py
+++ b/scripts/generate_png_icons.py
@@ -2,16 +2,17 @@ import os
 import sys
 import re
 
+
 def generate_icons(output_dir=None, bg_color=None):
     # Use script-relative paths for reliability
     script_dir = os.path.dirname(os.path.abspath(__file__))
     project_root = os.path.abspath(os.path.join(script_dir, ".."))
 
-    svg_path = os.path.join(project_root, 'projects/app/assets/icon.svg')
+    svg_path = os.path.join(project_root, "projects/app/assets/icon.svg")
 
     # Default output directory
     if output_dir is None:
-        output_dir = os.path.join(project_root, 'projects/app/assets')
+        output_dir = os.path.join(project_root, "projects/app/assets")
     else:
         output_dir = os.path.abspath(output_dir)
 
@@ -19,19 +20,21 @@ def generate_icons(output_dir=None, bg_color=None):
         print(f"Error: {svg_path} not found.")
         return False
 
-    with open(svg_path, 'r', encoding='utf-8') as f:
+    with open(svg_path, "r", encoding="utf-8") as f:
         svg_content = f.read()
 
     if bg_color:
         # Flexible regex for <rect width="512" height="512" ... fill="...">
         # Matches regardless of attribute order and quotes
-        pattern = r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'][^>]*width=["\']512["\'][^>]*height=["\']512["\'])|' \
-                  r'(<rect\s+[^>]*width=["\']512["\'][^>]*height=["\']512["\'][^>]*fill=["\'])([^"\']+)(["\'])'
+        pattern = (
+            r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'][^>]*width=["\']512["\'][^>]*height=["\']512["\'])|'
+            r'(<rect\s+[^>]*width=["\']512["\'][^>]*height=["\']512["\'][^>]*fill=["\'])([^"\']+)(["\'])'
+        )
 
         def replace_fill(match):
-            if match.group(1): # fill comes before width/height
+            if match.group(1):  # fill comes before width/height
                 return f"{match.group(1)}{bg_color}{match.group(3)}"
-            else: # fill comes after width/height
+            else:  # fill comes after width/height
                 return f"{match.group(4)}{bg_color}{match.group(6)}"
 
         if re.search(pattern, svg_content):
@@ -41,14 +44,19 @@ def generate_icons(output_dir=None, bg_color=None):
             # Fallback: find the first rect with a fill attribute
             fallback_pattern = r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'])'
             if re.search(fallback_pattern, svg_content):
-                svg_content = re.sub(fallback_pattern, rf'\1{bg_color}\3', svg_content, count=1)
+                svg_content = re.sub(
+                    fallback_pattern, rf"\1{bg_color}\3", svg_content, count=1
+                )
                 print(f"Background color changed to {bg_color} (using fallback regex)")
 
     try:
         from playwright.sync_api import sync_playwright
+
         print("Playwright found. Generating icons...")
     except ImportError:
-        print("Error: No module named 'playwright'. Please install it to generate extension icons.")
+        print(
+            "Error: No module named 'playwright'. Please install it to generate extension icons."
+        )
         return False
 
     if not os.path.exists(output_dir):
@@ -59,17 +67,19 @@ def generate_icons(output_dir=None, bg_color=None):
             browser = p.chromium.launch()
         except Exception as e:
             print(f"Error: Failed to launch browser: {e}")
-            print("Hint: Try running 'playwright install chromium' or 'npx playwright install chromium'.")
+            print(
+                "Hint: Try running 'playwright install chromium' or 'npx playwright install chromium'."
+            )
             return False
 
         context = browser.new_context(
-            viewport={'width': 512, 'height': 512},
-            device_scale_factor=1
+            viewport={"width": 512, "height": 512}, device_scale_factor=1
         )
         page = context.new_page()
 
         # Use a template literal to safely inject SVG content that might contain braces
-        page.set_content("""
+        page.set_content(
+            """
             <!DOCTYPE html>
             <html>
             <head>
@@ -79,28 +89,32 @@ def generate_icons(output_dir=None, bg_color=None):
             </style>
             </head>
             <body>
-            """ + svg_content + """
+            """
+            + svg_content
+            + """
             </body>
             </html>
-        """)
+        """
+        )
 
         for size in [16, 32, 48, 128]:
             output_path = os.path.join(output_dir, f"icon{size}.png")
             print(f"Generating {size}x{size} icon: {output_path}")
 
-            page.set_viewport_size({'width': size, 'height': size})
+            page.set_viewport_size({"width": size, "height": size})
             # Ensure SVG has time to render if it has transitions or complex filters
             page.wait_for_timeout(100)
             page.screenshot(
                 path=output_path,
                 omit_background=True,
-                clip={'x': 0, 'y': 0, 'width': size, 'height': size}
+                clip={"x": 0, "y": 0, "width": size, "height": size},
             )
 
         browser.close()
 
     print(f"Icon generation complete in {output_dir}")
     return True
+
 
 if __name__ == "__main__":
     target_dir = sys.argv[1] if len(sys.argv) > 1 else None

--- a/scripts/generate_png_icons.py
+++ b/scripts/generate_png_icons.py
@@ -1,0 +1,86 @@
+import os
+import sys
+import re
+
+def generate_icons(output_dir=None, bg_color=None):
+    # Base path for the source SVG
+    svg_path = os.path.join(os.getcwd(), 'projects/app/assets/icon.svg')
+
+    # Default output directory
+    if output_dir is None:
+        output_dir = os.path.join(os.getcwd(), 'projects/app/assets')
+
+    if not os.path.exists(svg_path):
+        print(f"Error: {svg_path} not found.")
+        return False
+
+    with open(svg_path, 'r', encoding='utf-8') as f:
+        svg_content = f.read()
+
+    if bg_color:
+        # Improved replacement logic using regex to identify the background rect (512x512)
+        pattern = r'(<rect\s+[^>]*width="512"\s+[^>]*height="512"\s+[^>]*fill=")([^"]+)(")'
+        if re.search(pattern, svg_content):
+            svg_content = re.sub(pattern, rf'\1{bg_color}\3', svg_content)
+            print(f"Background color dynamically changed to {bg_color}")
+        else:
+            # Fallback if the strict pattern doesn't match
+            svg_content = re.sub(r'(<rect\s+[^>]*fill=")([^"]+)(")', rf'\1{bg_color}\3', svg_content, count=1)
+            print(f"Background color changed to {bg_color} (using fallback regex)")
+
+    try:
+        from playwright.sync_api import sync_playwright
+        print("Playwright found. Generating icons...")
+    except ImportError:
+        print("Error: No module named 'playwright'. Please install it to generate extension icons.")
+        return False
+
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    with sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except Exception as e:
+            print(f"Error: Failed to launch browser: {e}")
+            return False
+
+        context = browser.new_context(
+            viewport={'width': 512, 'height': 512},
+            device_scale_factor=1
+        )
+        page = context.new_page()
+
+        page.set_content(f"""
+            <style>
+              body, html {{ margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; }}
+              svg {{ width: 100%; height: 100%; display: block; }}
+            </style>
+            {svg_content}
+        """)
+
+        for size in [16, 32, 48, 128]:
+            output_path = os.path.join(output_dir, f"icon{size}.png")
+            print(f"Generating {size}x{size} icon: {output_path}")
+
+            page.set_viewport_size({'width': size, 'height': size})
+            page.screenshot(
+                path=output_path,
+                omit_background=True,
+                clip={'x': 0, 'y': 0, 'width': size, 'height': size}
+            )
+
+        browser.close()
+
+    print(f"Icon generation complete in {output_dir}")
+    return True
+
+if __name__ == "__main__":
+    # Support optional command line arguments: [output_dir] [bg_color]
+    target_dir = sys.argv[1] if len(sys.argv) > 1 else None
+    color = sys.argv[2] if len(sys.argv) > 2 else None
+
+    if generate_icons(target_dir, color):
+        exit(0)
+    else:
+        exit(1)

--- a/scripts/generate_png_icons.py
+++ b/scripts/generate_png_icons.py
@@ -2,7 +2,6 @@ import os
 import sys
 import re
 
-
 def generate_icons(output_dir=None, bg_color=None):
     # Use script-relative paths for reliability
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -19,43 +18,62 @@ def generate_icons(output_dir=None, bg_color=None):
         print(f"Error: {svg_path} not found.")
         return False
 
-    with open(svg_path, "r", encoding="utf-8") as f:
+    with open(svg_path, 'r', encoding='utf-8') as f:
         svg_content = f.read()
 
     if bg_color:
-        # Flexible regex for <rect width="512" height="512" ... fill="...">
-        # Matches regardless of attribute order and quotes
-        pattern = (
-            r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'][^>]*width=["\']512["\'][^>]*height=["\']512["\'])|'
-            r'(<rect\s+[^>]*width=["\']512["\'][^>]*height=["\']512["\'][^>]*fill=["\'])([^"\']+)(["\'])'
-        )
+        try:
+            import xml.etree.ElementTree as ET
 
-        def replace_fill(match):
-            if match.group(1):  # fill comes before width/height
-                return f"{match.group(1)}{bg_color}{match.group(3)}"
-            else:  # fill comes after width/height
-                return f"{match.group(4)}{bg_color}{match.group(6)}"
+            # Register namespace to avoid 'ns0' prefixes in output
+            ET.register_namespace("", "http://www.w3.org/2000/svg")
+            root = ET.fromstring(svg_content)
 
-        if re.search(pattern, svg_content):
-            svg_content = re.sub(pattern, replace_fill, svg_content)
-            print(f"Background color dynamically changed to {bg_color}")
-        else:
-            # Fallback: find the first rect with a fill attribute
-            fallback_pattern = r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'])'
-            if re.search(fallback_pattern, svg_content):
-                svg_content = re.sub(
-                    fallback_pattern, rf"\1{bg_color}\3", svg_content, count=1
-                )
-                print(f"Background color changed to {bg_color} (using fallback regex)")
+            # Find the background rect (512x512)
+            found = False
+            for rect in root.iter():
+                if rect.tag.endswith("rect"):
+                    if rect.get("width") == "512" and rect.get("height") == "512":
+                        rect.set("fill", bg_color)
+                        found = True
+                        break
+
+            if found:
+                svg_content = ET.tostring(root, encoding="unicode")
+                print(f"Background color dynamically changed to {bg_color} using XML parser")
+            else:
+                print("Warning: Background rect (512x512) not found. Using regex fallback.")
+                raise ValueError("Background rect not found")
+
+        except Exception as e:
+            # Fallback to regex if XML parsing fails or target not found
+            pattern = (
+                r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'][^>]*width=["\']512["\'][^>]*height=["\']512["\'])|'
+                r'(<rect\s+[^>]*width=["\']512["\'][^>]*height=["\']512["\'][^>]*fill=["\'])([^"\']+)(["\'])'
+            )
+
+            def replace_fill(match):
+                if match.group(1):  # fill comes before width/height
+                    return f"{match.group(1)}{bg_color}{match.group(3)}"
+                else:  # fill comes after width/height
+                    return f"{match.group(4)}{bg_color}{match.group(6)}"
+
+            if re.search(pattern, svg_content):
+                svg_content = re.sub(pattern, replace_fill, svg_content)
+                print(f"Background color changed to {bg_color} (regex fallback)")
+            else:
+                fallback_pattern = r'(<rect\s+[^>]*fill=["\'])([^"\']+)(["\'])'
+                if re.search(fallback_pattern, svg_content):
+                    svg_content = re.sub(
+                        fallback_pattern, rf"\1{bg_color}\3", svg_content, count=1
+                    )
+                    print(f"Background color changed to {bg_color} (first rect fallback)")
 
     try:
         from playwright.sync_api import sync_playwright
-
         print("Playwright found. Generating icons...")
     except ImportError:
-        print(
-            "Error: No module named 'playwright'. Please install it to generate extension icons."
-        )
+        print("Error: No module named 'playwright'. Please install it to generate extension icons.")
         return False
 
     if not os.path.exists(output_dir):
@@ -66,19 +84,17 @@ def generate_icons(output_dir=None, bg_color=None):
             browser = p.chromium.launch()
         except Exception as e:
             print(f"Error: Failed to launch browser: {e}")
-            print(
-                "Hint: Try running 'playwright install chromium' or 'npx playwright install chromium'."
-            )
+            print("Hint: Try running 'playwright install chromium' or 'npx playwright install chromium'.")
             return False
 
         context = browser.new_context(
-            viewport={"width": 512, "height": 512}, device_scale_factor=1
+            viewport={'width': 512, 'height': 512},
+            device_scale_factor=1
         )
         page = context.new_page()
 
         # Use a template literal to safely inject SVG content that might contain braces
-        page.set_content(
-            """
+        page.set_content("""
             <!DOCTYPE html>
             <html>
             <head>
@@ -88,32 +104,28 @@ def generate_icons(output_dir=None, bg_color=None):
             </style>
             </head>
             <body>
-            """
-            + svg_content
-            + """
+            """ + svg_content + """
             </body>
             </html>
-        """
-        )
+        """)
 
         for size in [16, 32, 48, 128]:
             output_path = os.path.join(output_dir, f"icon{size}.png")
             print(f"Generating {size}x{size} icon: {output_path}")
 
-            page.set_viewport_size({"width": size, "height": size})
+            page.set_viewport_size({'width': size, 'height': size})
             # Ensure SVG has time to render if it has transitions or complex filters
             page.wait_for_timeout(100)
             page.screenshot(
                 path=output_path,
                 omit_background=True,
-                clip={"x": 0, "y": 0, "width": size, "height": size},
+                clip={'x': 0, 'y': 0, 'width': size, 'height': size}
             )
 
         browser.close()
 
     print(f"Icon generation complete in {output_dir}")
     return True
-
 
 if __name__ == "__main__":
     target_dir = sys.argv[1] if len(sys.argv) > 1 else None

--- a/scripts/generate_png_icons.py
+++ b/scripts/generate_png_icons.py
@@ -2,37 +2,48 @@ import os
 import sys
 import re
 
+
 def generate_icons(output_dir=None, bg_color=None):
     # Base path for the source SVG
-    svg_path = os.path.join(os.getcwd(), 'projects/app/assets/icon.svg')
+    svg_path = os.path.join(os.getcwd(), "projects/app/assets/icon.svg")
 
     # Default output directory
     if output_dir is None:
-        output_dir = os.path.join(os.getcwd(), 'projects/app/assets')
+        output_dir = os.path.join(os.getcwd(), "projects/app/assets")
 
     if not os.path.exists(svg_path):
         print(f"Error: {svg_path} not found.")
         return False
 
-    with open(svg_path, 'r', encoding='utf-8') as f:
+    with open(svg_path, "r", encoding="utf-8") as f:
         svg_content = f.read()
 
     if bg_color:
         # Improved replacement logic using regex to identify the background rect (512x512)
-        pattern = r'(<rect\s+[^>]*width="512"\s+[^>]*height="512"\s+[^>]*fill=")([^"]+)(")'
+        pattern = (
+            r'(<rect\s+[^>]*width="512"\s+[^>]*height="512"\s+[^>]*fill=")([^"]+)(")'
+        )
         if re.search(pattern, svg_content):
-            svg_content = re.sub(pattern, rf'\1{bg_color}\3', svg_content)
+            svg_content = re.sub(pattern, rf"\1{bg_color}\3", svg_content)
             print(f"Background color dynamically changed to {bg_color}")
         else:
             # Fallback if the strict pattern doesn't match
-            svg_content = re.sub(r'(<rect\s+[^>]*fill=")([^"]+)(")', rf'\1{bg_color}\3', svg_content, count=1)
+            svg_content = re.sub(
+                r'(<rect\s+[^>]*fill=")([^"]+)(")',
+                rf"\1{bg_color}\3",
+                svg_content,
+                count=1,
+            )
             print(f"Background color changed to {bg_color} (using fallback regex)")
 
     try:
         from playwright.sync_api import sync_playwright
+
         print("Playwright found. Generating icons...")
     except ImportError:
-        print("Error: No module named 'playwright'. Please install it to generate extension icons.")
+        print(
+            "Error: No module named 'playwright'. Please install it to generate extension icons."
+        )
         return False
 
     if not os.path.exists(output_dir):
@@ -46,8 +57,7 @@ def generate_icons(output_dir=None, bg_color=None):
             return False
 
         context = browser.new_context(
-            viewport={'width': 512, 'height': 512},
-            device_scale_factor=1
+            viewport={"width": 512, "height": 512}, device_scale_factor=1
         )
         page = context.new_page()
 
@@ -63,17 +73,18 @@ def generate_icons(output_dir=None, bg_color=None):
             output_path = os.path.join(output_dir, f"icon{size}.png")
             print(f"Generating {size}x{size} icon: {output_path}")
 
-            page.set_viewport_size({'width': size, 'height': size})
+            page.set_viewport_size({"width": size, "height": size})
             page.screenshot(
                 path=output_path,
                 omit_background=True,
-                clip={'x': 0, 'y': 0, 'width': size, 'height': size}
+                clip={"x": 0, "y": 0, "width": size, "height": size},
             )
 
         browser.close()
 
     print(f"Icon generation complete in {output_dir}")
     return True
+
 
 if __name__ == "__main__":
     # Support optional command line arguments: [output_dir] [bg_color]


### PR DESCRIPTION
Chrome拡張機能として必要なPNG形式のアイコン画像を生成する仕組みを導入し、Manifestファイルへの指定を行いました。

主な変更点：
1. **アイコン生成スクリプトの作成**: `scripts/generate_png_icons.py` を作成しました。`projects/app/assets/icon.svg` を元に、16, 32, 48, 128px の4種類のPNG画像を生成します。背景色の変更機能も保持しています。
2. **Manifestファイルの更新**: `projects/app/manifest.json` に `icons` および `action.default_icon` の指定を追加しました。
3. **ビルドプロセスの統合**: `package.json` の `build` スクリプトを更新し、パッケージ作成前にアイコン生成と既存のバリデーションスクリプト（バージョン整合性チェック、プロジェクトポリシーチェック）を実行するようにしました。
4. **ワークフローの更新**: `.github/workflows/release_extension_packages.yml` を更新し、GitHub Actions 上でアイコン生成に必要な Playwright とそのブラウザバイナリがセットアップされるようにしました。
5. **依存関係と無視設定**: `package.json` に `playwright` を追加し、生成されるPNGファイルがリポジトリに含まれないよう `.gitignore` に追加しました。

`npm run build` を実行することで、アイコンの生成からバリデーション、パッケージングまでが一貫して行われるようになっています。

---
*PR created automatically by Jules for task [10860820240011557470](https://jules.google.com/task/10860820240011557470) started by @masanori-satake*