### PR TITLE
feat: 安全なメッセージ送信機能を追加し、拡張機能の状態を管理

### DIFF
--- a/projects/app/content.js
+++ b/projects/app/content.js
@@ -205,7 +205,10 @@
     if (!isExtensionContextAlive) return false;
 
     try {
-      if (!chrome?.runtime?.id || typeof chrome.runtime.sendMessage !== "function") {
+      if (
+        !chrome?.runtime?.id ||
+        typeof chrome.runtime.sendMessage !== "function"
+      ) {
         isExtensionContextAlive = false;
         return false;
       }
@@ -281,17 +284,19 @@
       isEditing = detectEditingStateFromDOM();
     }
 
-    if (!safeSendMessage({
-      type: "ISSUE_UPDATED",
-      data: {
-        issueKey,
-        title: getSummary(),
-        priority: getPriority(),
-        status: getStatus(),
-        isEditing,
-        url: window.location.href,
-      },
-    })) {
+    if (
+      !safeSendMessage({
+        type: "ISSUE_UPDATED",
+        data: {
+          issueKey,
+          title: getSummary(),
+          priority: getPriority(),
+          status: getStatus(),
+          isEditing,
+          url: window.location.href,
+        },
+      })
+    ) {
       return;
     }
     isEditingState = isEditing;

--- a/projects/app/content.js
+++ b/projects/app/content.js
@@ -199,6 +199,26 @@
   };
 
   let isEditingState = false;
+  let isExtensionContextAlive = true;
+
+  const safeSendMessage = (message) => {
+    if (!isExtensionContextAlive) return false;
+
+    try {
+      if (!chrome?.runtime?.id || typeof chrome.runtime.sendMessage !== "function") {
+        isExtensionContextAlive = false;
+        return false;
+      }
+
+      chrome.runtime.sendMessage(message).catch(() => {
+        isExtensionContextAlive = false;
+      });
+      return true;
+    } catch (error) {
+      isExtensionContextAlive = false;
+      return false;
+    }
+  };
 
   /**
    * 要素が保存またはキャンセルボタンかどうかを判定する
@@ -247,11 +267,13 @@
    * 変更をバックグラウンドに通知する
    */
   const notifyChange = (isEditing = null) => {
+    if (!isExtensionContextAlive) return;
+
     const issueKey = getIssueKey();
     lastNotifyTime = Date.now();
     if (!issueKey) {
       // 課題ページでない場合は、タブの関連付けを解除する
-      chrome.runtime.sendMessage({ type: "CLEAR_TAB_ASSOCIATION" });
+      safeSendMessage({ type: "CLEAR_TAB_ASSOCIATION" });
       return;
     }
 
@@ -259,7 +281,7 @@
       isEditing = detectEditingStateFromDOM();
     }
 
-    chrome.runtime.sendMessage({
+    if (!safeSendMessage({
       type: "ISSUE_UPDATED",
       data: {
         issueKey,
@@ -269,7 +291,9 @@
         isEditing,
         url: window.location.href,
       },
-    });
+    })) {
+      return;
+    }
     isEditingState = isEditing;
   };
 

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -1141,7 +1141,6 @@ confirmAddHostBtn.addEventListener("click", async () => {
       origin: normalizedHost.permissionOrigin,
     })
     .catch(() => {});
-
 });
 
 /**

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -1142,32 +1142,6 @@ confirmAddHostBtn.addEventListener("click", async () => {
     })
     .catch(() => {});
 
-  return;
-
-  {
-    let url = rawUrl;
-    try {
-      if (url.includes("://")) {
-        const parsedUrl = new URL(url);
-        // /browse/ や /issues/ より前のパスを保持する
-        const pathMatch = parsedUrl.pathname.match(/^(.*?)\/(?:browse|issues)/);
-        const contextPath = pathMatch ? pathMatch[1] : "";
-        url = parsedUrl.hostname + contextPath;
-      }
-    } catch (e) {
-      // パース失敗時はトリミングした入力をそのまま使用
-    }
-
-    const settings = await db.getSettings();
-    settings.push({
-      id: Date.now().toString(),
-      name,
-      url,
-      visible: true,
-    });
-    await db.setSettings(settings);
-    addHostDialog.classList.add("hidden");
-  }
 });
 
 /**


### PR DESCRIPTION
現在Chromeに機能拡張を入れ、実行すると以下のエラーがコンソールに出力されました。
行った操作はCloud版JiraのIssueを開いているタブを選択してActiveにしました。

`VM82 content.js:257 Uncaught TypeError: Cannot read properties of undefined (reading 'sendMessage')
    at notifyChange (VM82 content.js:257:20)
    at handleVisibilityChange (VM82 content.js:376:9)
notifyChange	@	VM82 content.js:257
handleVisibilityChange	@	VM82 content.js:376

VM193 content.js:257 Uncaught Error: Extension context invalidated.
    at notifyChange (VM193 content.js:257:20)
    at handleVisibilityChange (VM193 content.js:376:9)
VM198 content.js:262 Uncaught Error: Extension context invalidated.
    at notifyChange (VM198 content.js:262:20)
    at handleVisibilityChange (VM198 content.js:381:9)
content.js:262 Uncaught Error: Extension context invalidated.
    at notifyChange (content.js:262:20)
    at handleVisibilityChange (content.js:381:9)`