### PR TITLE
Address PR #37 comments: Implement resource cleanup in content.js

### DIFF
--- a/projects/app/content.js
+++ b/projects/app/content.js
@@ -199,6 +199,61 @@
   };
 
   let isEditingState = false;
+  let isExtensionContextAlive = true;
+
+  /**
+   * 監視を停止し、リソースを解放する
+   */
+  const stopExtensionMonitoring = () => {
+    // MutationObserverの停止
+    if (observer) {
+      observer.disconnect();
+    }
+
+    // デバウンスタイマーのクリア
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+
+    // イベントリスナーの削除
+    document.removeEventListener("focusin", startEditing);
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+    window.removeEventListener("focus", handleVisibilityChange);
+    document.removeEventListener("keydown", handleKeyDown, true);
+    document.removeEventListener("click", handleClick, true);
+  };
+
+  /**
+   * コンテキストの無効化を処理する
+   */
+  const invalidateContext = () => {
+    if (!isExtensionContextAlive) return;
+    isExtensionContextAlive = false;
+    stopExtensionMonitoring();
+  };
+
+  const safeSendMessage = (message) => {
+    if (!isExtensionContextAlive) return false;
+
+    try {
+      if (
+        !chrome?.runtime?.id ||
+        typeof chrome.runtime.sendMessage !== "function"
+      ) {
+        invalidateContext();
+        return false;
+      }
+
+      chrome.runtime.sendMessage(message).catch(() => {
+        invalidateContext();
+      });
+      return true;
+    } catch (error) {
+      invalidateContext();
+      return false;
+    }
+  };
 
   /**
    * 要素が保存またはキャンセルボタンかどうかを判定する
@@ -247,11 +302,13 @@
    * 変更をバックグラウンドに通知する
    */
   const notifyChange = (isEditing = null) => {
+    if (!isExtensionContextAlive) return;
+
     const issueKey = getIssueKey();
     lastNotifyTime = Date.now();
     if (!issueKey) {
       // 課題ページでない場合は、タブの関連付けを解除する
-      chrome.runtime.sendMessage({ type: "CLEAR_TAB_ASSOCIATION" });
+      safeSendMessage({ type: "CLEAR_TAB_ASSOCIATION" });
       return;
     }
 
@@ -259,17 +316,21 @@
       isEditing = detectEditingStateFromDOM();
     }
 
-    chrome.runtime.sendMessage({
-      type: "ISSUE_UPDATED",
-      data: {
-        issueKey,
-        title: getSummary(),
-        priority: getPriority(),
-        status: getStatus(),
-        isEditing,
-        url: window.location.href,
-      },
-    });
+    if (
+      !safeSendMessage({
+        type: "ISSUE_UPDATED",
+        data: {
+          issueKey,
+          title: getSummary(),
+          priority: getPriority(),
+          status: getStatus(),
+          isEditing,
+          url: window.location.href,
+        },
+      })
+    ) {
+      return;
+    }
     isEditingState = isEditing;
   };
 
@@ -369,6 +430,29 @@
     }
   };
 
+  /**
+   * キー操作による編集終了（EnterやEscape）を処理する
+   */
+  const handleKeyDown = (e) => {
+    if (isEditingState) {
+      if (e.key === "Escape") {
+        stopEditing();
+      } else if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+        stopEditing();
+      }
+    }
+  };
+
+  /**
+   * 保存・キャンセルボタンのクリックを処理する
+   */
+  const handleClick = (e) => {
+    if (!isEditingState) return;
+    if (isSaveOrCancelButton(e.target)) {
+      stopEditing();
+    }
+  };
+
   // 編集状態の監視
   document.addEventListener("focusin", startEditing);
 
@@ -387,29 +471,8 @@
   window.addEventListener("focus", handleVisibilityChange);
 
   // キー操作による編集終了（EnterやEscape）の検知
-  document.addEventListener(
-    "keydown",
-    (e) => {
-      if (isEditingState) {
-        if (e.key === "Escape") {
-          stopEditing();
-        } else if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
-          stopEditing();
-        }
-      }
-    },
-    true,
-  );
+  document.addEventListener("keydown", handleKeyDown, true);
 
   // 保存・キャンセルボタンのクリックを検知
-  document.addEventListener(
-    "click",
-    (e) => {
-      if (!isEditingState) return;
-      if (isSaveOrCancelButton(e.target)) {
-        stopEditing();
-      }
-    },
-    true,
-  );
+  document.addEventListener("click", handleClick, true);
 })();

--- a/projects/app/content.js
+++ b/projects/app/content.js
@@ -119,7 +119,7 @@
         text = text.trim();
 
         if (text) {
-          // キーワードがそのまま含まれているか確認 (大文字小文字を区別しない)
+          // キーキーワードがそのまま含まれているか確認 (大文字小文字を区別しない)
           for (const kw of PRIORITY_KEYWORDS) {
             if (new RegExp(kw, "i").test(text)) return kw;
           }
@@ -200,6 +200,11 @@
 
   let isEditingState = false;
   let isExtensionContextAlive = true;
+  let observer = null;
+  let debounceTimer = null;
+  let lastNotifyTime = 0;
+  let lastUrl = location.href;
+  let lastInfo = "";
 
   /**
    * 監視を停止し、リソースを解放する
@@ -208,6 +213,7 @@
     // MutationObserverの停止
     if (observer) {
       observer.disconnect();
+      observer = null;
     }
 
     // デバウンスタイマーのクリア
@@ -233,6 +239,9 @@
     stopExtensionMonitoring();
   };
 
+  /**
+   * 安全にメッセージをバックグラウンドに送信する
+   */
   const safeSendMessage = (message) => {
     if (!isExtensionContextAlive) return false;
 
@@ -296,8 +305,6 @@
     return false;
   };
 
-  let lastNotifyTime = 0;
-
   /**
    * 変更をバックグラウンドに通知する
    */
@@ -334,17 +341,12 @@
     isEditingState = isEditing;
   };
 
-  // 初回実行
-  notifyChange();
-
-  let lastUrl = location.href;
-  let lastInfo = "";
-  let debounceTimer = null;
-
   /**
    * 課題情報の変更をチェックし、変化があれば通知する
    */
   const checkInfoChange = () => {
+    if (!isExtensionContextAlive) return;
+
     const isEditing = detectEditingStateFromDOM();
     const info = JSON.stringify({
       s: getSummary(),
@@ -372,22 +374,12 @@
     );
   };
 
-  // DOMの変化を監視してリアルタイムに更新（デバウンス処理と範囲絞り込みで負荷を軽減）
-  const observer = new MutationObserver(() => {
-    const url = location.href;
-    if (url !== lastUrl) {
-      lastUrl = url;
-      // ページ遷移（SPA）時は即座に再判定
-      notifyChange();
-      // SPA遷移後はターゲット要素が変わっている可能性があるため再接続を検討
-      reconnectObserver();
-    } else {
-      if (debounceTimer) clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(checkInfoChange, 200);
-    }
-  });
-
+  /**
+   * MutationObserverを再接続する
+   */
   const reconnectObserver = () => {
+    if (!isExtensionContextAlive || !observer) return;
+
     observer.disconnect();
     observer.observe(getObserverTarget(), {
       subtree: true,
@@ -395,8 +387,6 @@
       characterData: true,
     });
   };
-
-  reconnectObserver();
 
   const isEditableElement = (el) => {
     if (!el) return false;
@@ -453,10 +443,9 @@
     }
   };
 
-  // 編集状態の監視
-  document.addEventListener("focusin", startEditing);
-
-  // タブの表示状態やウィンドウのフォーカスを監視して、最終表示時刻を更新する
+  /**
+   * タブの表示状態やウィンドウのフォーカスを監視して、最終表示時刻を更新する
+   */
   const handleVisibilityChange = () => {
     if (document.visibilityState === "visible" && getIssueKey()) {
       const now = Date.now();
@@ -467,12 +456,31 @@
     }
   };
 
+  // 1. 初回実行
+  notifyChange();
+
+  // 2. MutationObserverの初期化と開始
+  observer = new MutationObserver(() => {
+    if (!isExtensionContextAlive) return;
+
+    const url = location.href;
+    if (url !== lastUrl) {
+      lastUrl = url;
+      // ページ遷移（SPA）時は即座に再判定
+      notifyChange();
+      // SPA遷移後はターゲット要素が変わっている可能性があるため再接続を検討
+      reconnectObserver();
+    } else {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(checkInfoChange, 200);
+    }
+  });
+  reconnectObserver();
+
+  // 3. イベントリスナーの登録
+  document.addEventListener("focusin", startEditing);
   document.addEventListener("visibilitychange", handleVisibilityChange);
   window.addEventListener("focus", handleVisibilityChange);
-
-  // キー操作による編集終了（EnterやEscape）の検知
   document.addEventListener("keydown", handleKeyDown, true);
-
-  // 保存・キャンセルボタンのクリックを検知
   document.addEventListener("click", handleClick, true);
 })();

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -1141,33 +1141,6 @@ confirmAddHostBtn.addEventListener("click", async () => {
       origin: normalizedHost.permissionOrigin,
     })
     .catch(() => {});
-
-  return;
-
-  {
-    let url = rawUrl;
-    try {
-      if (url.includes("://")) {
-        const parsedUrl = new URL(url);
-        // /browse/ や /issues/ より前のパスを保持する
-        const pathMatch = parsedUrl.pathname.match(/^(.*?)\/(?:browse|issues)/);
-        const contextPath = pathMatch ? pathMatch[1] : "";
-        url = parsedUrl.hostname + contextPath;
-      }
-    } catch (e) {
-      // パース失敗時はトリミングした入力をそのまま使用
-    }
-
-    const settings = await db.getSettings();
-    settings.push({
-      id: Date.now().toString(),
-      name,
-      url,
-      visible: true,
-    });
-    await db.setSettings(settings);
-    addHostDialog.classList.add("hidden");
-  }
 });
 
 /**


### PR DESCRIPTION
PR #37のコメントに基づき、拡張機能のコンテキストが無効化（更新やリロードなど）された際に、`content.js`が保持しているリソース（MutationObserver、デバウンスタイマー、イベントリスナー）を確実に解放する仕組みを導入しました。これにより、古いコンテキストのスクリプトがページに残った場合でも、不要な負荷やエラーの発生を抑制できます。

---
*PR created automatically by Jules for task [13756196339807570494](https://jules.google.com/task/13756196339807570494) started by @masanori-satake*