### PR TITLE
Fix settings drag-and-drop reordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.12.4-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.12.5-blue)](manifest.json)
 [![Coverage](https://img.shields.io/badge/coverage-51%25-orange)](#)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.12.4",
+      "version": "0.12.5",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/generate_png_icons.py && python3 scripts/check_version.py && python3 scripts/verify_project_policies.py && python3 scripts/build.py",

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/projects/app/modules/settings-manager.js
+++ b/projects/app/modules/settings-manager.js
@@ -13,6 +13,8 @@ export class SettingsManager {
     this.db = db;
     this.renderer = renderer;
     this.previousMaxHistoryCount = 50;
+    this.draggingIndex = null;
+    this.draggingType = null;
 
     // UI要素のキャッシュ
     this.elements = {
@@ -149,9 +151,61 @@ export class SettingsManager {
     // ドラッグ＆ドロップ用イベント
     li.addEventListener("dragstart", (e) => {
       li.classList.add("dragging");
-      e.dataTransfer.setData("text/plain", index);
+      this.draggingIndex = index;
+      this.draggingType = "host";
+      e.dataTransfer.effectAllowed = "move";
     });
-    li.addEventListener("dragend", () => li.classList.remove("dragging"));
+
+    li.addEventListener("dragover", (e) => {
+      if (this.draggingType !== "host") return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      const rect = li.getBoundingClientRect();
+      const midpoint = rect.top + rect.height / 2;
+      if (e.clientY < midpoint) {
+        li.classList.add("drag-over-top");
+        li.classList.remove("drag-over-bottom");
+      } else {
+        li.classList.add("drag-over-bottom");
+        li.classList.remove("drag-over-top");
+      }
+    });
+
+    li.addEventListener("dragleave", () => {
+      li.classList.remove("drag-over-top", "drag-over-bottom");
+    });
+
+    li.addEventListener("dragend", () => {
+      li.classList.remove("dragging", "drag-over-top", "drag-over-bottom");
+      this.draggingIndex = null;
+      this.draggingType = null;
+    });
+
+    li.addEventListener("drop", async (e) => {
+      if (this.draggingType !== "host") return;
+      e.preventDefault();
+      li.classList.remove("drag-over-top", "drag-over-bottom");
+
+      const fromIndex = this.draggingIndex;
+      const toIndex = index;
+
+      if (fromIndex === toIndex) return;
+
+      const rect = li.getBoundingClientRect();
+      const midpoint = rect.top + rect.height / 2;
+      const dropPosition = e.clientY < midpoint ? "top" : "bottom";
+
+      let finalToIndex = toIndex;
+      if (dropPosition === "bottom" && fromIndex > toIndex) finalToIndex++;
+      if (dropPosition === "top" && fromIndex < toIndex) finalToIndex--;
+
+      const newSettings = [...allSettings];
+      const [movedItem] = newSettings.splice(fromIndex, 1);
+      newSettings.splice(finalToIndex, 0, movedItem);
+
+      await this.db.setSettings(newSettings);
+      this.renderHostSettings();
+    });
 
     return li;
   }
@@ -222,9 +276,61 @@ export class SettingsManager {
 
     li.addEventListener("dragstart", (e) => {
       li.classList.add("dragging");
-      e.dataTransfer.setData("text/plain", index);
+      this.draggingIndex = index;
+      this.draggingType = "project";
+      e.dataTransfer.effectAllowed = "move";
     });
-    li.addEventListener("dragend", () => li.classList.remove("dragging"));
+
+    li.addEventListener("dragover", (e) => {
+      if (this.draggingType !== "project") return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      const rect = li.getBoundingClientRect();
+      const midpoint = rect.top + rect.height / 2;
+      if (e.clientY < midpoint) {
+        li.classList.add("drag-over-top");
+        li.classList.remove("drag-over-bottom");
+      } else {
+        li.classList.add("drag-over-bottom");
+        li.classList.remove("drag-over-top");
+      }
+    });
+
+    li.addEventListener("dragleave", () => {
+      li.classList.remove("drag-over-top", "drag-over-bottom");
+    });
+
+    li.addEventListener("dragend", () => {
+      li.classList.remove("dragging", "drag-over-top", "drag-over-bottom");
+      this.draggingIndex = null;
+      this.draggingType = null;
+    });
+
+    li.addEventListener("drop", async (e) => {
+      if (this.draggingType !== "project") return;
+      e.preventDefault();
+      li.classList.remove("drag-over-top", "drag-over-bottom");
+
+      const fromIndex = this.draggingIndex;
+      const toIndex = index;
+
+      if (fromIndex === toIndex) return;
+
+      const rect = li.getBoundingClientRect();
+      const midpoint = rect.top + rect.height / 2;
+      const dropPosition = e.clientY < midpoint ? "top" : "bottom";
+
+      let finalToIndex = toIndex;
+      if (dropPosition === "bottom" && fromIndex > toIndex) finalToIndex++;
+      if (dropPosition === "top" && fromIndex < toIndex) finalToIndex--;
+
+      const newSettings = [...allSettings];
+      const [movedItem] = newSettings.splice(fromIndex, 1);
+      newSettings.splice(finalToIndex, 0, movedItem);
+
+      await this.db.setProjectSettings(newSettings);
+      this.renderProjectSettings();
+    });
 
     return li;
   }

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -531,6 +531,14 @@ section:last-child {
   border: 1px dashed var(--border-color);
 }
 
+.host-item.drag-over-top {
+  border-top: 2px solid #0052cc;
+}
+
+.host-item.drag-over-bottom {
+  border-bottom: 2px solid #0052cc;
+}
+
 .drag-handle {
   cursor: grab;
   color: #ccc;
@@ -611,6 +619,14 @@ section:last-child {
 .project-item.dragging {
   opacity: 0.5;
   border: 1px dashed var(--border-color);
+}
+
+.project-item.drag-over-top {
+  border-top: 2px solid #0052cc;
+}
+
+.project-item.drag-over-bottom {
+  border-bottom: 2px solid #0052cc;
 }
 
 .project-key-label {

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -532,11 +532,11 @@ section:last-child {
 }
 
 .host-item.drag-over-top {
-  border-top: 2px solid #0052cc;
+  box-shadow: inset 0 2px 0 0 #0052cc;
 }
 
 .host-item.drag-over-bottom {
-  border-bottom: 2px solid #0052cc;
+  box-shadow: inset 0 -2px 0 0 #0052cc;
 }
 
 .drag-handle {
@@ -622,11 +622,11 @@ section:last-child {
 }
 
 .project-item.drag-over-top {
-  border-top: 2px solid #0052cc;
+  box-shadow: inset 0 2px 0 0 #0052cc;
 }
 
 .project-item.drag-over-bottom {
-  border-bottom: 2px solid #0052cc;
+  box-shadow: inset 0 -2px 0 0 #0052cc;
 }
 
 .project-key-label {

--- a/tests/e2e/settings-drag-drop.spec.js
+++ b/tests/e2e/settings-drag-drop.spec.js
@@ -30,14 +30,8 @@ test.describe("Settings Reordering", () => {
     const hostItems = sidePanel.locator(".host-item");
     await expect(hostItems).toHaveCount(2);
 
-    const firstHostName = await hostItems
-      .nth(0)
-      .locator(".host-name")
-      .textContent();
-    const secondHostName = await hostItems
-      .nth(1)
-      .locator(".host-name")
-      .textContent();
+    const firstHostName = await hostItems.nth(0).locator(".host-name").textContent();
+    const secondHostName = await hostItems.nth(1).locator(".host-name").textContent();
 
     expect(firstHostName).toBe("Jira Cloud");
     expect(secondHostName).toBe("Second Jira");
@@ -50,25 +44,17 @@ test.describe("Settings Reordering", () => {
     await sidePanel.mouse.down();
     // Move to the top half of the first host to trigger 'top' drop position
     const box = await firstHost.boundingBox();
-    await sidePanel.mouse.move(box.x + box.width / 2, box.y + box.height / 4, {
-      steps: 5,
-    });
+    await sidePanel.mouse.move(box.x + box.width / 2, box.y + box.height / 4, { steps: 5 });
     await sidePanel.mouse.up();
 
     // Verify order changed
-    await expect(hostItems.nth(0).locator(".host-name")).toHaveText(
-      "Second Jira",
-    );
-    await expect(hostItems.nth(1).locator(".host-name")).toHaveText(
-      "Jira Cloud",
-    );
+    await expect(hostItems.nth(0).locator(".host-name")).toHaveText("Second Jira");
+    await expect(hostItems.nth(1).locator(".host-name")).toHaveText("Jira Cloud");
 
     // Reload sidepanel to verify persistence
     await sidePanel.reload();
     await sidePanel.click("#settings-btn");
-    await expect(
-      sidePanel.locator(".host-item").nth(0).locator(".host-name"),
-    ).toHaveText("Second Jira");
+    await expect(sidePanel.locator(".host-item").nth(0).locator(".host-name")).toHaveText("Second Jira");
   });
 
   test("should reorder project keys via drag and drop", async ({}, testInfo) => {
@@ -88,12 +74,8 @@ test.describe("Settings Reordering", () => {
     const projectItems = sidePanel.locator(".project-item");
     await expect(projectItems).toHaveCount(2);
 
-    expect(
-      await projectItems.nth(0).locator(".project-key-label").textContent(),
-    ).toBe("AAA");
-    expect(
-      await projectItems.nth(1).locator(".project-key-label").textContent(),
-    ).toBe("BBB");
+    expect(await projectItems.nth(0).locator(".project-key-label").textContent()).toBe("AAA");
+    expect(await projectItems.nth(1).locator(".project-key-label").textContent()).toBe("BBB");
 
     // Drag BBB to the top
     const firstProj = projectItems.nth(0);
@@ -102,25 +84,17 @@ test.describe("Settings Reordering", () => {
     await secondProj.hover();
     await sidePanel.mouse.down();
     const box = await firstProj.boundingBox();
-    await sidePanel.mouse.move(box.x + box.width / 2, box.y + box.height / 4, {
-      steps: 5,
-    });
+    await sidePanel.mouse.move(box.x + box.width / 2, box.y + box.height / 4, { steps: 5 });
     await sidePanel.mouse.up();
 
     // Verify order changed
-    await expect(projectItems.nth(0).locator(".project-key-label")).toHaveText(
-      "BBB",
-    );
-    await expect(projectItems.nth(1).locator(".project-key-label")).toHaveText(
-      "AAA",
-    );
+    await expect(projectItems.nth(0).locator(".project-key-label")).toHaveText("BBB");
+    await expect(projectItems.nth(1).locator(".project-key-label")).toHaveText("AAA");
 
     // Reload sidepanel to verify persistence
     await sidePanel.reload();
     await sidePanel.click("#settings-btn");
     await sidePanel.click('[data-tab="projects"]');
-    await expect(
-      sidePanel.locator(".project-item").nth(0).locator(".project-key-label"),
-    ).toHaveText("BBB");
+    await expect(sidePanel.locator(".project-item").nth(0).locator(".project-key-label")).toHaveText("BBB");
   });
 });

--- a/tests/e2e/settings-drag-drop.spec.js
+++ b/tests/e2e/settings-drag-drop.spec.js
@@ -30,8 +30,14 @@ test.describe("Settings Reordering", () => {
     const hostItems = sidePanel.locator(".host-item");
     await expect(hostItems).toHaveCount(2);
 
-    const firstHostName = await hostItems.nth(0).locator(".host-name").textContent();
-    const secondHostName = await hostItems.nth(1).locator(".host-name").textContent();
+    const firstHostName = await hostItems
+      .nth(0)
+      .locator(".host-name")
+      .textContent();
+    const secondHostName = await hostItems
+      .nth(1)
+      .locator(".host-name")
+      .textContent();
 
     expect(firstHostName).toBe("Jira Cloud");
     expect(secondHostName).toBe("Second Jira");
@@ -44,17 +50,25 @@ test.describe("Settings Reordering", () => {
     await sidePanel.mouse.down();
     // Move to the top half of the first host to trigger 'top' drop position
     const box = await firstHost.boundingBox();
-    await sidePanel.mouse.move(box.x + box.width / 2, box.y + box.height / 4, { steps: 5 });
+    await sidePanel.mouse.move(box.x + box.width / 2, box.y + box.height / 4, {
+      steps: 5,
+    });
     await sidePanel.mouse.up();
 
     // Verify order changed
-    await expect(hostItems.nth(0).locator(".host-name")).toHaveText("Second Jira");
-    await expect(hostItems.nth(1).locator(".host-name")).toHaveText("Jira Cloud");
+    await expect(hostItems.nth(0).locator(".host-name")).toHaveText(
+      "Second Jira",
+    );
+    await expect(hostItems.nth(1).locator(".host-name")).toHaveText(
+      "Jira Cloud",
+    );
 
     // Reload sidepanel to verify persistence
     await sidePanel.reload();
     await sidePanel.click("#settings-btn");
-    await expect(sidePanel.locator(".host-item").nth(0).locator(".host-name")).toHaveText("Second Jira");
+    await expect(
+      sidePanel.locator(".host-item").nth(0).locator(".host-name"),
+    ).toHaveText("Second Jira");
   });
 
   test("should reorder project keys via drag and drop", async ({}, testInfo) => {
@@ -74,8 +88,12 @@ test.describe("Settings Reordering", () => {
     const projectItems = sidePanel.locator(".project-item");
     await expect(projectItems).toHaveCount(2);
 
-    expect(await projectItems.nth(0).locator(".project-key-label").textContent()).toBe("AAA");
-    expect(await projectItems.nth(1).locator(".project-key-label").textContent()).toBe("BBB");
+    expect(
+      await projectItems.nth(0).locator(".project-key-label").textContent(),
+    ).toBe("AAA");
+    expect(
+      await projectItems.nth(1).locator(".project-key-label").textContent(),
+    ).toBe("BBB");
 
     // Drag BBB to the top
     const firstProj = projectItems.nth(0);
@@ -84,17 +102,25 @@ test.describe("Settings Reordering", () => {
     await secondProj.hover();
     await sidePanel.mouse.down();
     const box = await firstProj.boundingBox();
-    await sidePanel.mouse.move(box.x + box.width / 2, box.y + box.height / 4, { steps: 5 });
+    await sidePanel.mouse.move(box.x + box.width / 2, box.y + box.height / 4, {
+      steps: 5,
+    });
     await sidePanel.mouse.up();
 
     // Verify order changed
-    await expect(projectItems.nth(0).locator(".project-key-label")).toHaveText("BBB");
-    await expect(projectItems.nth(1).locator(".project-key-label")).toHaveText("AAA");
+    await expect(projectItems.nth(0).locator(".project-key-label")).toHaveText(
+      "BBB",
+    );
+    await expect(projectItems.nth(1).locator(".project-key-label")).toHaveText(
+      "AAA",
+    );
 
     // Reload sidepanel to verify persistence
     await sidePanel.reload();
     await sidePanel.click("#settings-btn");
     await sidePanel.click('[data-tab="projects"]');
-    await expect(sidePanel.locator(".project-item").nth(0).locator(".project-key-label")).toHaveText("BBB");
+    await expect(
+      sidePanel.locator(".project-item").nth(0).locator(".project-key-label"),
+    ).toHaveText("BBB");
   });
 });

--- a/tests/e2e/settings-drag-drop.spec.js
+++ b/tests/e2e/settings-drag-drop.spec.js
@@ -1,0 +1,100 @@
+import { test, expect } from "./fixtures";
+
+test.describe("Settings Reordering", () => {
+  test.beforeEach(async ({ context, extensionId }) => {
+    const sidePanel = await context.newPage();
+    await sidePanel.addInitScript(() => {
+      window.chrome = window.chrome || {};
+      window.chrome.permissions = window.chrome.permissions || {};
+      window.chrome.permissions.request = async () => true;
+      window.alert = () => {};
+    });
+    await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
+    test.info().annotations.push({ type: "sidePanel", description: sidePanel });
+  });
+
+  async function getSidePanel(testInfo) {
+    return testInfo.annotations.find((a) => a.type === "sidePanel").description;
+  }
+
+  test("should reorder Jira hosts via drag and drop", async ({}, testInfo) => {
+    const sidePanel = await getSidePanel(testInfo);
+    await sidePanel.click("#settings-btn");
+
+    // Add a second host
+    await sidePanel.click("#add-host-btn");
+    await sidePanel.fill("#host-name", "Second Jira");
+    await sidePanel.fill("#host-url", "second.atlassian.net");
+    await sidePanel.click("#confirm-add-host");
+
+    const hostItems = sidePanel.locator(".host-item");
+    await expect(hostItems).toHaveCount(2);
+
+    const firstHostName = await hostItems.nth(0).locator(".host-name").textContent();
+    const secondHostName = await hostItems.nth(1).locator(".host-name").textContent();
+
+    expect(firstHostName).toBe("Jira Cloud");
+    expect(secondHostName).toBe("Second Jira");
+
+    // Drag the second host to the top
+    const firstHost = hostItems.nth(0);
+    const secondHost = hostItems.nth(1);
+
+    await secondHost.hover();
+    await sidePanel.mouse.down();
+    // Move to the top half of the first host to trigger 'top' drop position
+    const box = await firstHost.boundingBox();
+    await sidePanel.mouse.move(box.x + box.width / 2, box.y + box.height / 4, { steps: 5 });
+    await sidePanel.mouse.up();
+
+    // Verify order changed
+    await expect(hostItems.nth(0).locator(".host-name")).toHaveText("Second Jira");
+    await expect(hostItems.nth(1).locator(".host-name")).toHaveText("Jira Cloud");
+
+    // Reload sidepanel to verify persistence
+    await sidePanel.reload();
+    await sidePanel.click("#settings-btn");
+    await expect(sidePanel.locator(".host-item").nth(0).locator(".host-name")).toHaveText("Second Jira");
+  });
+
+  test("should reorder project keys via drag and drop", async ({}, testInfo) => {
+    const sidePanel = await getSidePanel(testInfo);
+    await sidePanel.click("#settings-btn");
+    await sidePanel.click('[data-tab="projects"]');
+
+    // Add two projects
+    await sidePanel.click("#add-project-btn");
+    await sidePanel.fill("#project-key-input", "AAA");
+    await sidePanel.click("#confirm-add-project");
+
+    await sidePanel.click("#add-project-btn");
+    await sidePanel.fill("#project-key-input", "BBB");
+    await sidePanel.click("#confirm-add-project");
+
+    const projectItems = sidePanel.locator(".project-item");
+    await expect(projectItems).toHaveCount(2);
+
+    expect(await projectItems.nth(0).locator(".project-key-label").textContent()).toBe("AAA");
+    expect(await projectItems.nth(1).locator(".project-key-label").textContent()).toBe("BBB");
+
+    // Drag BBB to the top
+    const firstProj = projectItems.nth(0);
+    const secondProj = projectItems.nth(1);
+
+    await secondProj.hover();
+    await sidePanel.mouse.down();
+    const box = await firstProj.boundingBox();
+    await sidePanel.mouse.move(box.x + box.width / 2, box.y + box.height / 4, { steps: 5 });
+    await sidePanel.mouse.up();
+
+    // Verify order changed
+    await expect(projectItems.nth(0).locator(".project-key-label")).toHaveText("BBB");
+    await expect(projectItems.nth(1).locator(".project-key-label")).toHaveText("AAA");
+
+    // Reload sidepanel to verify persistence
+    await sidePanel.reload();
+    await sidePanel.click("#settings-btn");
+    await sidePanel.click('[data-tab="projects"]');
+    await expect(sidePanel.locator(".project-item").nth(0).locator(".project-key-label")).toHaveText("BBB");
+  });
+});

--- a/tests/unit/settings-manager.test.js
+++ b/tests/unit/settings-manager.test.js
@@ -199,7 +199,9 @@ describe("SettingsManager", () => {
     const dropEvent = new Event("drop");
     dropEvent.preventDefault = jest.fn();
     dropEvent.clientY = 1000; // Large value to simulate bottom
-    secondItem.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100, height: 50 });
+    secondItem.getBoundingClientRect = jest
+      .fn()
+      .mockReturnValue({ top: 100, height: 50 });
     secondItem.dispatchEvent(dropEvent);
 
     expect(db.setSettings).toHaveBeenCalled();
@@ -232,7 +234,9 @@ describe("SettingsManager", () => {
     const dropEvent = new Event("drop");
     dropEvent.preventDefault = jest.fn();
     dropEvent.clientY = 1000; // Large value to simulate bottom
-    secondItem.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100, height: 50 });
+    secondItem.getBoundingClientRect = jest
+      .fn()
+      .mockReturnValue({ top: 100, height: 50 });
     secondItem.dispatchEvent(dropEvent);
 
     expect(db.setProjectSettings).toHaveBeenCalled();

--- a/tests/unit/settings-manager.test.js
+++ b/tests/unit/settings-manager.test.js
@@ -199,9 +199,7 @@ describe("SettingsManager", () => {
     const dropEvent = new Event("drop");
     dropEvent.preventDefault = jest.fn();
     dropEvent.clientY = 1000; // Large value to simulate bottom
-    secondItem.getBoundingClientRect = jest
-      .fn()
-      .mockReturnValue({ top: 100, height: 50 });
+    secondItem.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100, height: 50 });
     secondItem.dispatchEvent(dropEvent);
 
     expect(db.setSettings).toHaveBeenCalled();
@@ -234,9 +232,7 @@ describe("SettingsManager", () => {
     const dropEvent = new Event("drop");
     dropEvent.preventDefault = jest.fn();
     dropEvent.clientY = 1000; // Large value to simulate bottom
-    secondItem.getBoundingClientRect = jest
-      .fn()
-      .mockReturnValue({ top: 100, height: 50 });
+    secondItem.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100, height: 50 });
     secondItem.dispatchEvent(dropEvent);
 
     expect(db.setProjectSettings).toHaveBeenCalled();

--- a/tests/unit/settings-manager.test.js
+++ b/tests/unit/settings-manager.test.js
@@ -174,4 +174,70 @@ describe("SettingsManager", () => {
       document.getElementById("add-host-dialog").classList.contains("hidden"),
     ).toBe(true);
   });
+
+  test("should reorder hosts via drag and drop", async () => {
+    const mockSettings = [
+      { id: "1", name: "Host 1", url: "host1.net", visible: true },
+      { id: "2", name: "Host 2", url: "host2.net", visible: true },
+    ];
+    db.getSettings.mockResolvedValue(mockSettings);
+
+    await manager.renderHostSettings();
+    const items = document.querySelectorAll(".host-item");
+    const firstItem = items[0];
+    const secondItem = items[1];
+
+    // Simulate drag start on Host 1
+    const dragStartEvent = new Event("dragstart");
+    dragStartEvent.dataTransfer = { setData: jest.fn(), effectAllowed: null };
+    firstItem.dispatchEvent(dragStartEvent);
+
+    expect(manager.draggingIndex).toBe(0);
+    expect(manager.draggingType).toBe("host");
+
+    // Simulate drop on Host 2 (at the bottom)
+    const dropEvent = new Event("drop");
+    dropEvent.preventDefault = jest.fn();
+    dropEvent.clientY = 1000; // Large value to simulate bottom
+    secondItem.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100, height: 50 });
+    secondItem.dispatchEvent(dropEvent);
+
+    expect(db.setSettings).toHaveBeenCalled();
+    const newSettings = db.setSettings.mock.calls[0][0];
+    expect(newSettings[0].name).toBe("Host 2");
+    expect(newSettings[1].name).toBe("Host 1");
+  });
+
+  test("should reorder projects via drag and drop", async () => {
+    const mockProj = [
+      { key: "PROJ1", color: "#0061A4" },
+      { key: "PROJ2", color: "#0061A4" },
+    ];
+    db.getProjectSettings.mockResolvedValue(mockProj);
+
+    await manager.renderProjectSettings();
+    const items = document.querySelectorAll(".project-item");
+    const firstItem = items[0];
+    const secondItem = items[1];
+
+    // Simulate drag start on Project 1
+    const dragStartEvent = new Event("dragstart");
+    dragStartEvent.dataTransfer = { setData: jest.fn(), effectAllowed: null };
+    firstItem.dispatchEvent(dragStartEvent);
+
+    expect(manager.draggingIndex).toBe(0);
+    expect(manager.draggingType).toBe("project");
+
+    // Simulate drop on Project 2 (at the bottom)
+    const dropEvent = new Event("drop");
+    dropEvent.preventDefault = jest.fn();
+    dropEvent.clientY = 1000; // Large value to simulate bottom
+    secondItem.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100, height: 50 });
+    secondItem.dispatchEvent(dropEvent);
+
+    expect(db.setProjectSettings).toHaveBeenCalled();
+    const newSettings = db.setProjectSettings.mock.calls[0][0];
+    expect(newSettings[0].key).toBe("PROJ2");
+    expect(newSettings[1].key).toBe("PROJ1");
+  });
 });


### PR DESCRIPTION
This PR fixes a bug where Jira sites and project keys in the settings panel could not be reordered via drag-and-drop.

Key changes:
- Updated `projects/app/modules/settings-manager.js` to handle drop events and update the underlying data order.
- Added CSS styles in `projects/app/sidepanel.css` to provide visual feedback (blue insertion lines) during dragging.
- Added unit tests in `tests/unit/settings-manager.test.js` to verify the reordering logic.
- Added E2E tests in `tests/e2e/settings-drag-drop.spec.js` to ensure the UI behavior is correct.
- Incremented the project version to 0.12.5 as required for changes in `projects/app/`.

Verification:
- All unit tests passed (`npm test`).
- Frontend verification was performed using a custom Playwright script that demonstrated successful reordering and visual indicators.

---
*PR created automatically by Jules for task [7183814305373069352](https://jules.google.com/task/7183814305373069352) started by @masanori-satake*