### PR TITLE
Improve Settings Usability: In-place Editing for Hosts and Project Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.12.5-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.12.6-blue)](manifest.json)
 [![Coverage](https://img.shields.io/badge/coverage-51%25-orange)](#)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/generate_png_icons.py && python3 scripts/check_version.py && python3 scripts/verify_project_policies.py && python3 scripts/build.py",

--- a/projects/app/_locales/en/messages.json
+++ b/projects/app/_locales/en/messages.json
@@ -226,5 +226,8 @@
   },
   "permissionDenied": {
     "message": "Host access permission is required to track issues on this Jira site."
+  },
+  "duplicateProjectKey": {
+    "message": "This project key is already registered."
   }
 }

--- a/projects/app/_locales/en/messages.json
+++ b/projects/app/_locales/en/messages.json
@@ -104,8 +104,17 @@
   "ok": {
     "message": "OK"
   },
+  "save": {
+    "message": "Save"
+  },
+  "update": {
+    "message": "Update"
+  },
   "addProjectTitle": {
     "message": "Add Project Key"
+  },
+  "editProjectTitle": {
+    "message": "Edit Project Key"
   },
   "projectKey": {
     "message": "Project Key"
@@ -115,6 +124,9 @@
   },
   "addHostTitle": {
     "message": "Add Jira Host"
+  },
+  "editHostTitle": {
+    "message": "Edit Jira Host"
   },
   "hostName": {
     "message": "Display Name"

--- a/projects/app/_locales/ja/messages.json
+++ b/projects/app/_locales/ja/messages.json
@@ -104,8 +104,17 @@
   "ok": {
     "message": "OK"
   },
+  "save": {
+    "message": "保存"
+  },
+  "update": {
+    "message": "変更"
+  },
   "addProjectTitle": {
     "message": "プロジェクトキーの追加"
+  },
+  "editProjectTitle": {
+    "message": "プロジェクトキーの編集"
   },
   "projectKey": {
     "message": "プロジェクトキー"
@@ -115,6 +124,9 @@
   },
   "addHostTitle": {
     "message": "Jiraホストの追加"
+  },
+  "editHostTitle": {
+    "message": "Jiraホストの編集"
   },
   "hostName": {
     "message": "表示名"

--- a/projects/app/_locales/ja/messages.json
+++ b/projects/app/_locales/ja/messages.json
@@ -226,5 +226,8 @@
   },
   "permissionDenied": {
     "message": "この Jira サイトで課題を追跡するには、ホスト権限の許可が必要です。"
+  },
+  "duplicateProjectKey": {
+    "message": "このプロジェクトキーは既に登録されています。"
   }
 }

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/projects/app/modules/settings-manager.js
+++ b/projects/app/modules/settings-manager.js
@@ -23,8 +23,8 @@ export class SettingsManager {
       projectList: document.getElementById("project-list"),
       maxHistoryRange: document.getElementById("max-history-range"),
       maxHistoryValue: document.getElementById("max-history-value"),
-      addHostDialog: document.getElementById("add-host-dialog"),
-      addProjectDialog: document.getElementById("add-project-dialog"),
+      hostDialog: document.getElementById("host-dialog"),
+      projectDialog: document.getElementById("project-dialog"),
       confirmDialog: document.getElementById("confirm-dialog"),
     };
   }
@@ -90,6 +90,11 @@ export class SettingsManager {
     urlSpan.textContent = host.url;
     info.appendChild(nameSpan);
     info.appendChild(urlSpan);
+
+    // クリックで編集
+    info.addEventListener("click", () => {
+      this.openHostDialog(host);
+    });
 
     // 表示切り替えトグル
     const toggle = document.createElement("div");
@@ -240,6 +245,9 @@ export class SettingsManager {
     const keyLabel = document.createElement("span");
     keyLabel.className = "project-key-label";
     keyLabel.textContent = proj.key;
+    keyLabel.addEventListener("click", () => {
+      this.openProjectDialog(proj);
+    });
 
     const colorPicker = document.createElement("div");
     colorPicker.className = "color-picker";
@@ -417,6 +425,38 @@ export class SettingsManager {
   }
 
   /**
+   * ホストダイアログを開きます。
+   */
+  openHostDialog(host = null) {
+    const dialog = this.elements.hostDialog;
+    const titleEl = document.getElementById("host-dialog-title");
+    const confirmBtn = document.getElementById("confirm-host");
+    const nameInput = document.getElementById("host-name");
+    const urlInput = document.getElementById("host-url");
+
+    if (host) {
+      dialog.dataset.editId = host.id;
+      titleEl.textContent = chrome.i18n.getMessage("editHostTitle");
+      titleEl.dataset.i18n = "editHostTitle";
+      confirmBtn.textContent = chrome.i18n.getMessage("update");
+      confirmBtn.dataset.i18n = "update";
+      nameInput.value = host.name;
+      urlInput.value = host.url;
+    } else {
+      delete dialog.dataset.editId;
+      titleEl.textContent = chrome.i18n.getMessage("addHostTitle");
+      titleEl.dataset.i18n = "addHostTitle";
+      confirmBtn.textContent = chrome.i18n.getMessage("add");
+      confirmBtn.dataset.i18n = "add";
+      nameInput.value = "";
+      urlInput.value = "";
+    }
+
+    dialog.classList.remove("hidden");
+    nameInput.focus();
+  }
+
+  /**
    * 新しいJiraホストを追加します。
    */
   async addHost(name, rawUrl) {
@@ -451,7 +491,7 @@ export class SettingsManager {
       visible: true,
     });
     await this.db.setSettings(nextSettings);
-    this.elements.addHostDialog.classList.add("hidden");
+    this.elements.hostDialog.classList.add("hidden");
     await this.renderHostSettings();
 
     chrome.runtime
@@ -460,5 +500,147 @@ export class SettingsManager {
         origin: normalized.permissionOrigin,
       })
       .catch(() => {});
+  }
+
+  /**
+   * Jiraホスト設定を更新します。
+   */
+  async updateHost(id, name, rawUrl) {
+    if (!name || !rawUrl) return;
+
+    let normalized;
+    try {
+      normalized = normalizeHostInput(rawUrl);
+    } catch (e) {
+      alert(chrome.i18n.getMessage("invalidHost"));
+      return;
+    }
+
+    const settings = await this.db.getSettings();
+    const index = settings.findIndex((h) => h.id === id);
+    if (index === -1) return;
+
+    const oldHost = settings[index];
+    const urlChanged = oldHost.url !== normalized.storedUrl;
+
+    if (urlChanged) {
+      // 権限の処理
+      const oldOrigin = getPermissionOriginFromStoredHost(oldHost.url);
+      const newOrigin = normalized.permissionOrigin;
+
+      // 古い権限の解放（他で使われていない場合）
+      if (oldOrigin && !isBuiltinHostOrigin(oldOrigin)) {
+        const stillNeeded = settings.some(
+          (h, i) =>
+            i !== index && getPermissionOriginFromStoredHost(h.url) === oldOrigin,
+        );
+        if (!stillNeeded) {
+          try {
+            await chrome.permissions.remove({ origins: [oldOrigin] });
+          } catch (e) {}
+        }
+      }
+
+      // 新しい権限の要求
+      if (!isBuiltinHostOrigin(newOrigin)) {
+        let granted = false;
+        try {
+          granted = await chrome.permissions.request({ origins: [newOrigin] });
+        } catch (e) {}
+        if (!granted) {
+          alert(chrome.i18n.getMessage("permissionDenied"));
+          return;
+        }
+      }
+    }
+
+    settings[index] = {
+      ...oldHost,
+      name,
+      url: normalized.storedUrl,
+    };
+
+    await this.db.setSettings(settings);
+    this.elements.hostDialog.classList.add("hidden");
+    await this.renderHostSettings();
+
+    if (urlChanged) {
+      chrome.runtime
+        .sendMessage({
+          type: "HOST_PERMISSION_GRANTED",
+          origin: normalized.permissionOrigin,
+        })
+        .catch(() => {});
+    }
+  }
+
+  /**
+   * プロジェクトダイアログを開きます。
+   */
+  openProjectDialog(proj = null) {
+    const dialog = this.elements.projectDialog;
+    const titleEl = document.getElementById("project-dialog-title");
+    const confirmBtn = document.getElementById("confirm-project");
+    const keyInput = document.getElementById("project-key-input");
+
+    if (proj) {
+      dialog.dataset.editKey = proj.key;
+      titleEl.textContent = chrome.i18n.getMessage("editProjectTitle");
+      titleEl.dataset.i18n = "editProjectTitle";
+      confirmBtn.textContent = chrome.i18n.getMessage("save");
+      confirmBtn.dataset.i18n = "save";
+      keyInput.value = proj.key;
+    } else {
+      delete dialog.dataset.editKey;
+      titleEl.textContent = chrome.i18n.getMessage("addProjectTitle");
+      titleEl.dataset.i18n = "addProjectTitle";
+      confirmBtn.textContent = chrome.i18n.getMessage("ok");
+      confirmBtn.dataset.i18n = "ok";
+      keyInput.value = "";
+    }
+
+    dialog.classList.remove("hidden");
+    keyInput.focus();
+  }
+
+  /**
+   * 新しいプロジェクトを追加します。
+   */
+  async addProject(key) {
+    const settings = await this.db.getProjectSettings();
+    if (settings.some((p) => p.key === key)) {
+      this.elements.projectDialog.classList.add("hidden");
+      return;
+    }
+
+    settings.push({ key, color: "#0061A4", isCollapsed: false });
+    await this.db.setProjectSettings(settings);
+    this.elements.projectDialog.classList.add("hidden");
+    await this.renderProjectSettings();
+  }
+
+  /**
+   * プロジェクト設定を更新します。
+   */
+  async updateProject(oldKey, newKey) {
+    const settings = await this.db.getProjectSettings();
+    const index = settings.findIndex((p) => p.key === oldKey);
+    if (index === -1) {
+      this.elements.projectDialog.classList.add("hidden");
+      return;
+    }
+
+    if (oldKey !== newKey) {
+      // 重複チェック
+      if (settings.some((p) => p.key === newKey)) {
+        // すでに存在する場合は何もしない（ダイアログは閉じる）
+        this.elements.projectDialog.classList.add("hidden");
+        return;
+      }
+      settings[index].key = newKey;
+      await this.db.setProjectSettings(settings);
+      await this.renderProjectSettings();
+    }
+    this.elements.projectDialog.classList.add("hidden");
   }
 }

--- a/projects/app/modules/settings-manager.js
+++ b/projects/app/modules/settings-manager.js
@@ -532,8 +532,7 @@ export class SettingsManager {
       if (oldOrigin && !isBuiltinHostOrigin(oldOrigin)) {
         const stillNeeded = settings.some(
           (h, i) =>
-            i !== index &&
-            getPermissionOriginFromStoredHost(h.url) === oldOrigin,
+            i !== index && getPermissionOriginFromStoredHost(h.url) === oldOrigin,
         );
         if (!stillNeeded) {
           try {

--- a/projects/app/modules/settings-manager.js
+++ b/projects/app/modules/settings-manager.js
@@ -532,8 +532,7 @@ export class SettingsManager {
       if (oldOrigin && !isBuiltinHostOrigin(oldOrigin)) {
         const stillNeeded = settings.some(
           (h, i) =>
-            i !== index &&
-            getPermissionOriginFromStoredHost(h.url) === oldOrigin,
+            i !== index && getPermissionOriginFromStoredHost(h.url) === oldOrigin,
         );
         if (!stillNeeded) {
           try {
@@ -583,6 +582,10 @@ export class SettingsManager {
     const titleEl = document.getElementById("project-dialog-title");
     const confirmBtn = document.getElementById("confirm-project");
     const keyInput = document.getElementById("project-key-input");
+    const errorMsg = document.getElementById("project-error-msg");
+
+    errorMsg.classList.add("hidden");
+    errorMsg.textContent = "";
 
     if (proj) {
       dialog.dataset.editKey = proj.key;
@@ -600,6 +603,14 @@ export class SettingsManager {
       keyInput.value = "";
     }
 
+    // 入力開始時にエラーメッセージを非表示にする
+    if (!keyInput.dataset.listenerAdded) {
+      keyInput.addEventListener("input", () => {
+        errorMsg.classList.add("hidden");
+      });
+      keyInput.dataset.listenerAdded = "true";
+    }
+
     dialog.classList.remove("hidden");
     keyInput.focus();
   }
@@ -610,14 +621,15 @@ export class SettingsManager {
   async addProject(key) {
     const settings = await this.db.getProjectSettings();
     if (settings.some((p) => p.key === key)) {
-      this.elements.projectDialog.classList.add("hidden");
-      return;
+      this._showProjectError(chrome.i18n.getMessage("duplicateProjectKey"));
+      return false;
     }
 
     settings.push({ key, color: "#0061A4", isCollapsed: false });
     await this.db.setProjectSettings(settings);
     this.elements.projectDialog.classList.add("hidden");
     await this.renderProjectSettings();
+    return true;
   }
 
   /**
@@ -628,20 +640,26 @@ export class SettingsManager {
     const index = settings.findIndex((p) => p.key === oldKey);
     if (index === -1) {
       this.elements.projectDialog.classList.add("hidden");
-      return;
+      return true;
     }
 
     if (oldKey !== newKey) {
       // 重複チェック
       if (settings.some((p) => p.key === newKey)) {
-        // すでに存在する場合は何もしない（ダイアログは閉じる）
-        this.elements.projectDialog.classList.add("hidden");
-        return;
+        this._showProjectError(chrome.i18n.getMessage("duplicateProjectKey"));
+        return false;
       }
       settings[index].key = newKey;
       await this.db.setProjectSettings(settings);
       await this.renderProjectSettings();
     }
     this.elements.projectDialog.classList.add("hidden");
+    return true;
+  }
+
+  _showProjectError(message) {
+    const errorMsg = document.getElementById("project-error-msg");
+    errorMsg.textContent = message;
+    errorMsg.classList.remove("hidden");
   }
 }

--- a/projects/app/modules/settings-manager.js
+++ b/projects/app/modules/settings-manager.js
@@ -532,7 +532,8 @@ export class SettingsManager {
       if (oldOrigin && !isBuiltinHostOrigin(oldOrigin)) {
         const stillNeeded = settings.some(
           (h, i) =>
-            i !== index && getPermissionOriginFromStoredHost(h.url) === oldOrigin,
+            i !== index &&
+            getPermissionOriginFromStoredHost(h.url) === oldOrigin,
         );
         if (!stillNeeded) {
           try {

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -556,6 +556,7 @@ section:last-child {
   flex-grow: 1;
   display: flex;
   flex-direction: column;
+  cursor: pointer;
 }
 
 .host-name {
@@ -636,6 +637,7 @@ section:last-child {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  cursor: pointer;
 }
 
 .color-picker {

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -231,6 +231,12 @@ header {
   color: var(--secondary-text);
 }
 
+.error-msg {
+  color: #b3261e;
+  font-size: 11px;
+  margin-top: 4px;
+}
+
 .host-group-header {
   background-color: #0061a4; /* Material 3 Blue - Jira-like */
   padding: 6px 16px;

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -320,6 +320,7 @@
             data-i18n-placeholder="projectKeyPlaceholder"
             placeholder="e.g., PROJ"
           />
+          <div id="project-error-msg" class="error-msg hidden"></div>
         </div>
         <div class="dialog-actions">
           <button id="cancel-project" class="text-btn" data-i18n="cancel">

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -305,9 +305,11 @@
       </div>
     </div>
 
-    <div id="add-project-dialog" class="overlay hidden">
+    <div id="project-dialog" class="overlay hidden">
       <div class="dialog">
-        <h3 data-i18n="addProjectTitle">Add Project Key</h3>
+        <h3 id="project-dialog-title" data-i18n="addProjectTitle">
+          Add Project Key
+        </h3>
         <div class="input-field">
           <label for="project-key-input" data-i18n="projectKey"
             >Project Key</label
@@ -320,19 +322,19 @@
           />
         </div>
         <div class="dialog-actions">
-          <button id="cancel-add-project" class="text-btn" data-i18n="cancel">
+          <button id="cancel-project" class="text-btn" data-i18n="cancel">
             Cancel
           </button>
-          <button id="confirm-add-project" class="text-btn" data-i18n="ok">
+          <button id="confirm-project" class="text-btn" data-i18n="ok">
             OK
           </button>
         </div>
       </div>
     </div>
 
-    <div id="add-host-dialog" class="overlay hidden">
+    <div id="host-dialog" class="overlay hidden">
       <div class="dialog">
-        <h3 data-i18n="addHostTitle">Add Jira Host</h3>
+        <h3 id="host-dialog-title" data-i18n="addHostTitle">Add Jira Host</h3>
         <div class="input-field">
           <label for="host-name" data-i18n="hostName">Display Name</label>
           <input
@@ -352,10 +354,10 @@
           />
         </div>
         <div class="dialog-actions">
-          <button id="cancel-add-host" class="text-btn" data-i18n="cancel">
+          <button id="cancel-host" class="text-btn" data-i18n="cancel">
             Cancel
           </button>
-          <button id="confirm-add-host" class="text-btn" data-i18n="add">
+          <button id="confirm-host" class="text-btn" data-i18n="add">
             Add
           </button>
         </div>

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -250,53 +250,53 @@ class SidePanel {
 
     // プロジェクト追加
     document.getElementById("add-project-btn").addEventListener("click", () => {
-      document.getElementById("add-project-dialog").classList.remove("hidden");
-      document.getElementById("project-key-input").value = "";
-      document.getElementById("project-key-input").focus();
+      this.settings.openProjectDialog();
+    });
+
+    document.getElementById("cancel-project").addEventListener("click", () => {
+      document.getElementById("project-dialog").classList.add("hidden");
     });
 
     document
-      .getElementById("cancel-add-project")
-      .addEventListener("click", () => {
-        document.getElementById("add-project-dialog").classList.add("hidden");
-      });
-
-    document
-      .getElementById("confirm-add-project")
+      .getElementById("confirm-project")
       .addEventListener("click", async () => {
         const key = document
           .getElementById("project-key-input")
           .value.trim()
           .toUpperCase();
         if (key) {
-          const settings = await this.db.getProjectSettings();
-          if (!settings.some((p) => p.key === key)) {
-            settings.push({ key, color: "#0061A4", isCollapsed: false });
-            await this.db.setProjectSettings(settings);
-            await this.settings.renderProjectSettings();
+          const dialog = document.getElementById("project-dialog");
+          const editKey = dialog.dataset.editKey;
+          if (editKey) {
+            await this.settings.updateProject(editKey, key);
+          } else {
+            await this.settings.addProject(key);
           }
-          document.getElementById("add-project-dialog").classList.add("hidden");
+          dialog.classList.add("hidden");
         }
       });
 
     // ホスト追加
     document.getElementById("add-host-btn").addEventListener("click", () => {
-      document.getElementById("add-host-dialog").classList.remove("hidden");
-      document.getElementById("host-name").value = "";
-      document.getElementById("host-url").value = "";
+      this.settings.openHostDialog();
     });
 
-    document.getElementById("cancel-add-host").addEventListener("click", () => {
-      document.getElementById("add-host-dialog").classList.add("hidden");
+    document.getElementById("cancel-host").addEventListener("click", () => {
+      document.getElementById("host-dialog").classList.add("hidden");
     });
 
-    document
-      .getElementById("confirm-add-host")
-      .addEventListener("click", () => {
-        const name = document.getElementById("host-name").value.trim();
-        const url = document.getElementById("host-url").value.trim();
+    document.getElementById("confirm-host").addEventListener("click", () => {
+      const dialog = document.getElementById("host-dialog");
+      const editId = dialog.dataset.editId;
+      const name = document.getElementById("host-name").value.trim();
+      const url = document.getElementById("host-url").value.trim();
+
+      if (editId) {
+        this.settings.updateHost(editId, name, url);
+      } else {
         this.settings.addHost(name, url);
-      });
+      }
+    });
 
     // メッセージ受信
     chrome.runtime.onMessage.addListener((message) => {

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -272,7 +272,6 @@ class SidePanel {
           } else {
             await this.settings.addProject(key);
           }
-          dialog.classList.add("hidden");
         }
       });
 

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -152,7 +152,7 @@ test.describe("Issues-Solo E2E", () => {
     // プロジェクトキーを追加
     await sidePanel.click("#add-project-btn");
     await sidePanel.fill("#project-key-input", "TEST");
-    await sidePanel.click("#confirm-add-project");
+    await sidePanel.click("#confirm-project");
 
     // プロジェクトグループのヘッダーが表示されることを確認
     await sidePanel.click("#close-settings");

--- a/tests/e2e/settings-drag-drop.spec.js
+++ b/tests/e2e/settings-drag-drop.spec.js
@@ -25,7 +25,7 @@ test.describe("Settings Reordering", () => {
     await sidePanel.click("#add-host-btn");
     await sidePanel.fill("#host-name", "Second Jira");
     await sidePanel.fill("#host-url", "second.atlassian.net");
-    await sidePanel.click("#confirm-add-host");
+    await sidePanel.click("#confirm-host");
 
     const hostItems = sidePanel.locator(".host-item");
     await expect(hostItems).toHaveCount(2);
@@ -79,11 +79,11 @@ test.describe("Settings Reordering", () => {
     // Add two projects
     await sidePanel.click("#add-project-btn");
     await sidePanel.fill("#project-key-input", "AAA");
-    await sidePanel.click("#confirm-add-project");
+    await sidePanel.click("#confirm-project");
 
     await sidePanel.click("#add-project-btn");
     await sidePanel.fill("#project-key-input", "BBB");
-    await sidePanel.click("#confirm-add-project");
+    await sidePanel.click("#confirm-project");
 
     const projectItems = sidePanel.locator(".project-item");
     await expect(projectItems).toHaveCount(2);

--- a/tests/e2e/sidepanel.spec.js
+++ b/tests/e2e/sidepanel.spec.js
@@ -57,7 +57,7 @@ test.describe("Sidepanel Features", () => {
     // プロジェクトを追加
     await sidePanel.click("#add-project-btn");
     await sidePanel.fill("#project-key-input", "NEWPROJ");
-    await sidePanel.click("#confirm-add-project");
+    await sidePanel.click("#confirm-project");
 
     // 追加されたことを確認
     await expect(
@@ -85,7 +85,7 @@ test.describe("Sidepanel Features", () => {
     await sidePanel.click("#add-host-btn");
     await sidePanel.fill("#host-name", "Custom Jira");
     await sidePanel.fill("#host-url", "jira.custom.com");
-    await sidePanel.click("#confirm-add-host");
+    await sidePanel.click("#confirm-host");
 
     // 追加されたことを確認
     const hostItem = sidePanel.locator(".host-item", {

--- a/tests/unit/settings-manager.test.js
+++ b/tests/unit/settings-manager.test.js
@@ -17,8 +17,17 @@ describe("SettingsManager", () => {
         <ul id="project-list"></ul>
         <input type="range" id="max-history-range">
         <span id="max-history-value"></span>
-        <div id="add-host-dialog" class="hidden"></div>
-        <div id="add-project-dialog" class="hidden"></div>
+        <div id="host-dialog" class="hidden">
+          <h3 id="host-dialog-title"></h3>
+          <input id="host-name">
+          <input id="host-url">
+          <button id="confirm-host"></button>
+        </div>
+        <div id="project-dialog" class="hidden">
+          <h3 id="project-dialog-title"></h3>
+          <input id="project-key-input">
+          <button id="confirm-project"></button>
+        </div>
         <div id="confirm-dialog" class="hidden">
           <span id="confirm-title"></span>
           <p id="confirm-message"></p>
@@ -171,7 +180,51 @@ describe("SettingsManager", () => {
 
     expect(db.setSettings).toHaveBeenCalled();
     expect(
-      document.getElementById("add-host-dialog").classList.contains("hidden"),
+      document.getElementById("host-dialog").classList.contains("hidden"),
+    ).toBe(true);
+  });
+
+  test("should update host", async () => {
+    const mockSettings = [
+      { id: "1", name: "Old Name", url: "old.atlassian.net", visible: true },
+    ];
+    db.getSettings.mockResolvedValue(mockSettings);
+
+    const newName = "New Name";
+    const newUrl = "new.atlassian.net";
+
+    await manager.updateHost("1", newName, newUrl);
+
+    expect(db.setSettings).toHaveBeenCalled();
+    const updated = db.setSettings.mock.calls[0][0][0];
+    expect(updated.name).toBe(newName);
+    expect(updated.url).toBe("new.atlassian.net");
+    expect(
+      document.getElementById("host-dialog").classList.contains("hidden"),
+    ).toBe(true);
+  });
+
+  test("should add project", async () => {
+    db.getProjectSettings.mockResolvedValue([]);
+    await manager.addProject("NEWPROJ");
+
+    expect(db.setProjectSettings).toHaveBeenCalled();
+    expect(
+      document.getElementById("project-dialog").classList.contains("hidden"),
+    ).toBe(true);
+  });
+
+  test("should update project", async () => {
+    const mockProj = [{ key: "OLDPROJ", color: "#0061A4" }];
+    db.getProjectSettings.mockResolvedValue(mockProj);
+
+    await manager.updateProject("OLDPROJ", "NEWPROJ");
+
+    expect(db.setProjectSettings).toHaveBeenCalled();
+    const updated = db.setProjectSettings.mock.calls[0][0][0];
+    expect(updated.key).toBe("NEWPROJ");
+    expect(
+      document.getElementById("project-dialog").classList.contains("hidden"),
     ).toBe(true);
   });
 


### PR DESCRIPTION
Improved the usability of the settings screen by allowing users to edit existing Jira host configurations and project keys directly.

Key changes:
- **Jira Host Editing:** Users can now click on a registered Jira host to edit its display name and URL. The extension handles Chrome host permissions automatically, requesting new ones for updated URLs and releasing old ones if they are no longer needed.
- **Project Key Editing:** Users can click on a project key to update it. The associated project color is maintained. Changing a project key automatically moves its historical issues to the "Other" group in the side panel.
- **UI Improvements:** Added visual cues (pointer cursor) for editable areas and unified the 'Add' and 'Edit' dialogs for a consistent experience.
- **Technical Refinement:** Refactored `SettingsManager` to encapsulate addition and update logic, updated unit tests to ensure stability, and bumped the extension version to 0.12.6.

---
*PR created automatically by Jules for task [8119415984132993436](https://jules.google.com/task/8119415984132993436) started by @masanori-satake*