### PR TITLE
Prevent false "Editing" mark on search bar focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.12.6-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.12.7-blue)](manifest.json)
 [![Coverage](https://img.shields.io/badge/coverage-51%25-orange)](#)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.12.6",
+      "version": "0.12.7",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/generate_png_icons.py && python3 scripts/check_version.py && python3 scripts/verify_project_policies.py && python3 scripts/build.py",

--- a/projects/app/content.js
+++ b/projects/app/content.js
@@ -279,8 +279,7 @@
     const isSave =
       text.includes("save") ||
       text.includes("保存") ||
-      (testId && testId.includes("save")) ||
-      button.type === "submit";
+      (testId && testId.includes("save"));
     const isCancel =
       text.includes("cancel") ||
       text.includes("キャンセル") ||
@@ -296,8 +295,13 @@
     const buttons = document.querySelectorAll('button, [role="button"]');
     for (const btn of buttons) {
       if (isSaveOrCancelButton(btn)) {
-        // ボタンが表示されている＝編集フォームが開いているとみなす
-        const hasEditable = !!document.querySelector(
+        // ボタンの近傍（同じフォームやコンテナ内）に編集可能要素があるか確認する。
+        // これにより、グローバルな検索バーのボタンなどとの誤認を防ぐ。
+        const container =
+          btn.closest("form, [role='dialog'], [data-testid*='editor'], .inline-edit-section") ||
+          document.body;
+
+        const hasEditable = !!container.querySelector(
           'textarea, [contenteditable="true"], [role="textbox"]',
         );
         if (hasEditable) return true;
@@ -335,6 +339,7 @@
 
     // 内部状態を更新し、checkInfoChangeとの二重通知を防ぐ
     lastInfo = JSON.stringify({
+      k: issueKey,
       s: summary,
       p: priority,
       st: status,
@@ -365,8 +370,12 @@
   const checkInfoChange = () => {
     if (!isExtensionContextAlive) return;
 
+    const issueKey = getIssueKey();
+    if (!issueKey) return;
+
     const isEditing = detectEditingStateFromDOM();
     const info = JSON.stringify({
+      k: issueKey,
       s: getSummary(),
       p: getPriority(),
       st: getStatus(),

--- a/projects/app/content.js
+++ b/projects/app/content.js
@@ -298,8 +298,9 @@
         // ボタンの近傍（同じフォームやコンテナ内）に編集可能要素があるか確認する。
         // これにより、グローバルな検索バーのボタンなどとの誤認を防ぐ。
         const container =
-          btn.closest("form, [role='dialog'], [data-testid*='editor'], .inline-edit-section") ||
-          document.body;
+          btn.closest(
+            "form, [role='dialog'], [data-testid*='editor'], .inline-edit-section",
+          ) || document.body;
 
         const hasEditable = !!container.querySelector(
           'textarea, [contenteditable="true"], [role="textbox"]',

--- a/projects/app/content.js
+++ b/projects/app/content.js
@@ -224,6 +224,7 @@
 
     // イベントリスナーの削除
     document.removeEventListener("focusin", startEditing);
+    document.removeEventListener("focusout", handleFocusOut);
     document.removeEventListener("visibilitychange", handleVisibilityChange);
     window.removeEventListener("focus", handleVisibilityChange);
     document.removeEventListener("keydown", handleKeyDown, true);
@@ -328,14 +329,26 @@
       isEditing = detectEditingStateFromDOM();
     }
 
+    const summary = getSummary();
+    const priority = getPriority();
+    const status = getStatus();
+
+    // 内部状態を更新し、checkInfoChangeとの二重通知を防ぐ
+    lastInfo = JSON.stringify({
+      s: summary,
+      p: priority,
+      st: status,
+      e: isEditing,
+    });
+
     if (
       !safeSendMessage({
         type: "ISSUE_UPDATED",
         data: {
           issueKey,
-          title: getSummary(),
-          priority: getPriority(),
-          status: getStatus(),
+          title: summary,
+          priority: priority,
+          status: status,
           isEditing,
           url: window.location.href,
         },
@@ -413,9 +426,20 @@
 
   const startEditing = (e) => {
     if (isEditableElement(e.target)) {
-      if (!isEditingState) {
-        notifyChange(true);
-      }
+      // フォーカスが入っただけでは即座に「編集中」とせず、
+      // 実際に保存・キャンセルボタンが存在するかどうかを確認する。
+      // JiraのDOM反映（ボタンの表示など）を待つため、少し遅延させてチェックを実行する。
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(checkInfoChange, 300);
+    }
+  };
+
+  const handleFocusOut = (e) => {
+    if (isEditableElement(e.target)) {
+      // フォーカスが外れた際も、即座に解除せずDOM状態を確認する。
+      // （ボタンをクリックしてフォーカスが外れた場合などを考慮）
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(checkInfoChange, 300);
     }
   };
 
@@ -484,6 +508,7 @@
 
   // 3. イベントリスナーの登録
   document.addEventListener("focusin", startEditing);
+  document.addEventListener("focusout", handleFocusOut);
   document.addEventListener("visibilitychange", handleVisibilityChange);
   window.addEventListener("focus", handleVisibilityChange);
   document.addEventListener("keydown", handleKeyDown, true);

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -80,10 +80,17 @@ test.describe("Issues-Solo E2E", () => {
     await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
 
     // テキストエリアにフォーカスして編集状態をトリガー
+    // 注: content.js の仕様変更により、フォーカスしただけでは「編集中」にならず、
+    // 保存・キャンセルボタンが存在する必要がある。
+    await page.evaluate(() => {
+      const btn = document.createElement("button");
+      btn.innerText = "Save";
+      document.body.appendChild(btn);
+    });
     await page.focus("#comment");
     await page.type("#comment", "Working on it");
 
-    // デバウンスとメッセージ送信を待機
+    // デバウンス（300ms）とメッセージ送信を待機
     await page.waitForTimeout(1000);
 
     // サイドパネルで「編集中」インジケーターが表示されることを確認

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -81,11 +81,17 @@ test.describe("Issues-Solo E2E", () => {
 
     // テキストエリアにフォーカスして編集状態をトリガー
     // 注: content.js の仕様変更により、フォーカスしただけでは「編集中」にならず、
-    // 保存・キャンセルボタンが存在する必要がある。
+    // 保存・キャンセルボタンが（同一コンテナ内に）存在する必要がある。
     await page.evaluate(() => {
+      const form = document.createElement("form");
+      form.id = "edit-form";
+      const textarea = document.getElementById("comment");
+      textarea.parentNode.insertBefore(form, textarea);
+      form.appendChild(textarea);
+
       const btn = document.createElement("button");
       btn.innerText = "Save";
-      document.body.appendChild(btn);
+      form.appendChild(btn);
     });
     await page.focus("#comment");
     await page.type("#comment", "Working on it");


### PR DESCRIPTION
This change refines the editing state detection logic in the Jira content script to prevent the global search bar and other non-edit fields from triggering the "Editing" mark. 

Key changes:
- Removed aggressive `notifyChange(true)` in the focus handler.
- Added a `focusout` listener to handle clearing the mark when leaving a field.
- Uses a 300ms delay to allow Jira's dynamic DOM (like the appearance of Save/Cancel buttons) to stabilize before checking the editing state.
- Ensures the state is always synchronized with the DOM-based detection (`detectEditingStateFromDOM`).
- Version bump to 0.12.7.

---
*PR created automatically by Jules for task [14554878990104348077](https://jules.google.com/task/14554878990104348077) started by @masanori-satake*