### PR TITLE
Fix "Editing" indicator bugs in Jira Cloud New UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.12.8-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.12.9-blue)](manifest.json)
 [![Coverage](https://img.shields.io/badge/coverage-51%25-orange)](#)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "jest": "^29.7.0",
         "jest-chrome": "^0.8.0",
         "jest-environment-jsdom": "^29.7.0",
-        "playwright": "1.58.0"
+        "playwright": "^1.58.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.12.8",
+      "version": "0.12.9",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "description": "JIRA閲覧履歴と編集状態を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/generate_png_icons.py && python3 scripts/check_version.py && python3 scripts/verify_project_policies.py && python3 scripts/build.py",

--- a/projects/app/content.js
+++ b/projects/app/content.js
@@ -273,7 +273,11 @@
     const button = el.closest('button, [role="button"]');
     if (!button) return false;
 
-    const testId = (button.getAttribute("data-testid") || "").toLowerCase();
+    const testId = (
+      button.getAttribute("data-testid") ||
+      button.getAttribute("data-test-id") ||
+      ""
+    ).toLowerCase();
 
     // ヘッダーやナビゲーション内のボタン（検索やグローバルな「作成」など）は除外する
     if (

--- a/projects/app/content.js
+++ b/projects/app/content.js
@@ -273,17 +273,24 @@
     const button = el.closest('button, [role="button"]');
     if (!button) return false;
 
-    // ヘッダーやナビゲーション内のボタン（検索など）は除外する
+    const testId = (button.getAttribute("data-testid") || "").toLowerCase();
+
+    // ヘッダーやナビゲーション内のボタン（検索やグローバルな「作成」など）は除外する
     if (
+      testId.includes("atlassian-navigation") ||
       button.closest(
-        'header, [data-testid="global-pages.header.pushed-navigation-header"]',
+        'header, [data-testid="global-pages.header.pushed-navigation-header"], [data-testid="atlassian-navigation"]',
       )
     ) {
       return false;
     }
 
+    // 監査ログの更新ボタンなどは除外
+    if (testId.includes("audit-log") && testId.includes("refresh")) {
+      return false;
+    }
+
     const text = button.innerText.trim().toLowerCase();
-    const testId = (button.getAttribute("data-testid") || "").toLowerCase();
     const ariaLabel = (button.getAttribute("aria-label") || "").toLowerCase();
 
     // 保存・作成・更新系キーワード
@@ -304,9 +311,10 @@
       keywords.some((kw) => target.includes(kw));
 
     const isSave =
-      matchKeywords(saveKeywords, text) ||
-      matchKeywords(saveKeywords, testId) ||
-      matchKeywords(saveKeywords, ariaLabel);
+      (matchKeywords(saveKeywords, text) ||
+        matchKeywords(saveKeywords, testId) ||
+        matchKeywords(saveKeywords, ariaLabel)) &&
+      !matchKeywords(["comment-text-area-placeholder"], testId);
 
     const isCancel =
       matchKeywords(cancelKeywords, text) ||
@@ -330,12 +338,17 @@
         const container =
           btn.closest(
             "form, [role='dialog'], [data-testid*='editor-container'], [data-component='editor'], .inline-edit-section",
-          ) ||
-          btn.closest("[data-testid*='editor']")?.parentElement ||
-          document.body;
+          ) || btn.closest("[data-testid*='editor']")?.parentElement;
 
-        const hasEditable = !!container.querySelector(
+        // ボタンが特定のコンテナ内にない場合は、広範囲（document.body）を探索する。
+        // ただし、グローバルな「作成」ボタンなどが除外されていることが前提。
+        const searchRoot = container || document.body;
+
+        const editables = searchRoot.querySelectorAll(
           'textarea, input:not([type="button"]):not([type="submit"]):not([type="checkbox"]):not([type="radio"]):not([type="hidden"]), [contenteditable="true"], [role="textbox"], [role="combobox"]',
+        );
+        const hasEditable = Array.from(editables).some((el) =>
+          isEditableElement(el),
         );
         if (hasEditable) return true;
       }
@@ -453,6 +466,16 @@
     const tagName = el.tagName;
     const role = el.getAttribute("role");
     const isContentEditable = el.isContentEditable;
+    const testId = (
+      el.getAttribute("data-testid") ||
+      el.getAttribute("data-test-id") ||
+      ""
+    ).toLowerCase();
+
+    // 検索窓などは編集対象から除外する
+    if (testId.includes("search")) {
+      return false;
+    }
 
     return (
       tagName === "TEXTAREA" ||

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/tests/unit/editing-detection.test.js
+++ b/tests/unit/editing-detection.test.js
@@ -1,0 +1,172 @@
+import { jest } from '@jest/globals';
+
+// content.js is an IIFE, so we need to extract or mock the functions.
+// For unit testing, we can define the functions in the test scope
+// mimicking the ones in content.js.
+
+describe("content.js editing state detection", () => {
+  const isSaveOrCancelButton = (el) => {
+    if (!el) return false;
+    const button = el.closest('button, [role="button"]');
+    if (!button) return false;
+
+    const testId = (button.getAttribute("data-testid") || "").toLowerCase();
+
+    // ヘッダーやナビゲーション内のボタン（検索やグローバルな「作成」など）は除外する
+    if (
+      testId.includes("atlassian-navigation") ||
+      button.closest(
+        'header, [data-testid="global-pages.header.pushed-navigation-header"], [data-testid="atlassian-navigation"]',
+      )
+    ) {
+      return false;
+    }
+
+    // 監査ログの更新ボタンなどは除外
+    if (testId.includes("audit-log") && testId.includes("refresh")) {
+      return false;
+    }
+
+    const text = (button.innerText || button.textContent || "").trim().toLowerCase();
+    const ariaLabel = (button.getAttribute("aria-label") || "").toLowerCase();
+
+    // 保存・作成・更新系キーワード
+    const saveKeywords = [
+      "save",
+      "保存",
+      "create",
+      "作成",
+      "update",
+      "更新",
+      "add",
+      "追加",
+    ];
+    // キャンセル系キーワード
+    const cancelKeywords = ["cancel", "キャンセル"];
+
+    const matchKeywords = (keywords, target) =>
+      keywords.some((kw) => target.includes(kw));
+
+    const isSave =
+      (matchKeywords(saveKeywords, text) ||
+        matchKeywords(saveKeywords, testId) ||
+        matchKeywords(saveKeywords, ariaLabel)) &&
+      !matchKeywords(["comment-text-area-placeholder"], testId);
+
+    const isCancel =
+      matchKeywords(cancelKeywords, text) ||
+      matchKeywords(cancelKeywords, testId) ||
+      matchKeywords(cancelKeywords, ariaLabel);
+
+    return isSave || isCancel;
+  };
+
+  const isEditableElement = (el) => {
+    if (!el) return false;
+    const tagName = el.tagName;
+    const role = el.getAttribute("role");
+    const isContentEditable = el.isContentEditable;
+    const testId = (
+      el.getAttribute("data-testid") ||
+      el.getAttribute("data-test-id") ||
+      ""
+    ).toLowerCase();
+
+    // 検索窓などは編集対象から除外する
+    if (testId.includes("search")) {
+      return false;
+    }
+
+    return (
+      tagName === "TEXTAREA" ||
+      (tagName === "INPUT" &&
+        !["button", "submit", "checkbox", "radio", "hidden"].includes(
+          el.type,
+        )) ||
+      isContentEditable ||
+      role === "textbox" ||
+      role === "combobox"
+    );
+  };
+
+  const detectEditingStateFromDOM = () => {
+    const buttons = document.querySelectorAll('button, [role="button"]');
+    for (const btn of buttons) {
+      if (isSaveOrCancelButton(btn)) {
+        const container =
+          btn.closest(
+            "form, [role='dialog'], [data-testid*='editor-container'], [data-component='editor'], .inline-edit-section",
+          ) || btn.closest("[data-testid*='editor']")?.parentElement;
+
+        const searchRoot = container || document.body;
+
+        const editables = searchRoot.querySelectorAll(
+          'textarea, input:not([type="button"]):not([type="submit"]):not([type="checkbox"]):not([type="radio"]):not([type="hidden"]), [contenteditable="true"], [role="textbox"], [role="combobox"]',
+        );
+        const hasEditable = Array.from(editables).some((el) =>
+          isEditableElement(el),
+        );
+        if (hasEditable) return true;
+      }
+    }
+    return false;
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test("should NOT detect editing for global navigation Create button", () => {
+    document.body.innerHTML = `
+      <div data-testid="atlassian-navigation">
+        <button data-testid="atlassian-navigation--create-button">作成</button>
+      </div>
+      <input data-test-id="search-dialog-input" value="some search text">
+    `;
+    expect(detectEditingStateFromDOM()).toBe(false);
+  });
+
+  test("should NOT detect editing for audit log refresh button", () => {
+    document.body.innerHTML = `
+      <button data-testid="automation-issue-audit-log.ui.refresh">更新</button>
+      <input data-test-id="search-dialog-input" value="some search text">
+    `;
+    expect(detectEditingStateFromDOM()).toBe(false);
+  });
+
+  test("should NOT detect editing for comment placeholder", () => {
+    document.body.innerHTML = `
+      <button data-testid="canned-comments.common.ui.comment-text-area-placeholder.textarea">コメントを追加する...</button>
+      <input data-test-id="search-dialog-input" value="some search text">
+    `;
+    expect(detectEditingStateFromDOM()).toBe(false);
+  });
+
+  test("should detect editing for real inline edit", () => {
+    document.body.innerHTML = `
+      <div class="inline-edit-section">
+        <textarea>Editing content</textarea>
+        <button>保存</button>
+        <button>キャンセル</button>
+      </div>
+    `;
+    expect(detectEditingStateFromDOM()).toBe(true);
+  });
+
+  test("should NOT detect editing when only search input is present and some random button exists", () => {
+    document.body.innerHTML = `
+      <input data-test-id="search-dialog-input" value="some search text">
+      <button>Random Button</button>
+    `;
+    expect(detectEditingStateFromDOM()).toBe(false);
+  });
+
+  test("should NOT detect editing even if save button exists but only search input is editable", () => {
+    // Tests isEditableElement exclusion in detectEditingStateFromDOM.
+    document.body.innerHTML = `
+      <button>保存</button>
+      <input data-test-id="search-dialog-input" value="some search text">
+    `;
+    expect(detectEditingStateFromDOM()).toBe(false);
+  });
+});

--- a/tests/unit/editing-detection.test.js
+++ b/tests/unit/editing-detection.test.js
@@ -1,4 +1,4 @@
-import { jest } from '@jest/globals';
+import { jest } from "@jest/globals";
 
 // content.js is an IIFE, so we need to extract or mock the functions.
 // For unit testing, we can define the functions in the test scope
@@ -27,7 +27,9 @@ describe("content.js editing state detection", () => {
       return false;
     }
 
-    const text = (button.innerText || button.textContent || "").trim().toLowerCase();
+    const text = (button.innerText || button.textContent || "")
+      .trim()
+      .toLowerCase();
     const ariaLabel = (button.getAttribute("aria-label") || "").toLowerCase();
 
     // 保存・作成・更新系キーワード
@@ -113,7 +115,7 @@ describe("content.js editing state detection", () => {
   };
 
   beforeEach(() => {
-    document.body.innerHTML = '';
+    document.body.innerHTML = "";
   });
 
   test("should NOT detect editing for global navigation Create button", () => {

--- a/tests/unit/editing-detection.test.js
+++ b/tests/unit/editing-detection.test.js
@@ -10,7 +10,11 @@ describe("content.js editing state detection", () => {
     const button = el.closest('button, [role="button"]');
     if (!button) return false;
 
-    const testId = (button.getAttribute("data-testid") || "").toLowerCase();
+    const testId = (
+      button.getAttribute("data-testid") ||
+      button.getAttribute("data-test-id") ||
+      ""
+    ).toLowerCase();
 
     // ヘッダーやナビゲーション内のボタン（検索やグローバルな「作成」など）は除外する
     if (

--- a/tests/unit/editing-detection.test.js
+++ b/tests/unit/editing-detection.test.js
@@ -1,4 +1,4 @@
-import { jest } from "@jest/globals";
+import { jest } from '@jest/globals';
 
 // content.js is an IIFE, so we need to extract or mock the functions.
 // For unit testing, we can define the functions in the test scope
@@ -27,9 +27,7 @@ describe("content.js editing state detection", () => {
       return false;
     }
 
-    const text = (button.innerText || button.textContent || "")
-      .trim()
-      .toLowerCase();
+    const text = (button.innerText || button.textContent || "").trim().toLowerCase();
     const ariaLabel = (button.getAttribute("aria-label") || "").toLowerCase();
 
     // 保存・作成・更新系キーワード
@@ -115,7 +113,7 @@ describe("content.js editing state detection", () => {
   };
 
   beforeEach(() => {
-    document.body.innerHTML = "";
+    document.body.innerHTML = '';
   });
 
   test("should NOT detect editing for global navigation Create button", () => {


### PR DESCRIPTION
Fixed a regression where the "Editing" (編集中) indicator in the Jira extension would incorrectly appear or persist.

Key changes:
1. Updated `isSaveOrCancelButton` in `content.js` to exclude:
   - Global navigation buttons (using `data-testid="atlassian-navigation..."` or parent containers).
   - Audit log refresh buttons.
   - Comment placeholders (`comment-text-area-placeholder`).
2. Updated `isEditableElement` to exclude inputs with `data-testid` or `data-test-id` containing "search".
3. Refined `detectEditingStateFromDOM` to ensure that even if a button is found, the presence of an editable element is validated using the new `isEditableElement` filters.
4. Added a comprehensive unit test suite (`tests/unit/editing-detection.test.js`) to verify these scenarios against actual Jira Cloud DOM snippets.
5. Incremented package version to 0.12.9.

---
*PR created automatically by Jules for task [7773146482862205578](https://jules.google.com/task/7773146482862205578) started by @masanori-satake*