### PR TITLE
設定パネルのレイアウト修正とAboutタブのクリーンアップ

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.13.2-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.13.3-blue)](manifest.json)
 [![Coverage](https://img.shields.io/badge/coverage-51%25-orange)](#)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "JIRA閲覧履歴を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/generate_png_icons.py && python3 scripts/check_version.py && python3 scripts/verify_project_policies.py && python3 scripts/build.py",

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -472,6 +472,7 @@ section:last-child {
 
 .import-mode-selector {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 12px;
   margin-top: 4px;

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -472,7 +472,6 @@ section:last-child {
 
 .import-mode-selector {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
   gap: 12px;
   margin-top: 4px;
@@ -795,6 +794,7 @@ section:last-child {
 .about-section {
   display: flex;
   flex-direction: column;
+  margin-bottom: 0;
 }
 
 .about-item {

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -471,18 +471,21 @@ section:last-child {
 }
 
 .import-mode-selector {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   margin-top: 4px;
 }
 
 .import-mode-selector label {
   font-size: 12px;
   color: var(--secondary-text);
+  white-space: nowrap;
 }
 
 .radio-group {
   display: flex;
-  gap: 16px;
-  margin-top: 4px;
+  gap: 12px;
 }
 
 .radio-group label {
@@ -785,7 +788,7 @@ section:last-child {
   line-height: 1.5;
   display: flex;
   flex-direction: column;
-  gap: 24px; /* Maintain gap between sections */
+  gap: 12px; /* Maintain gap between sections */
 }
 
 .about-section {

--- a/projects/app/sidepanel.html
+++ b/projects/app/sidepanel.html
@@ -262,7 +262,6 @@
             </section>
 
             <section class="about-section">
-              <div class="about-label">Issues-Solo</div>
               <p class="about-text" data-i18n="aboutDescription">
                 Issues-Solo is a privacy-focused Jira history tool. Data is
                 stored in IndexedDB within your browser and is never sent


### PR DESCRIPTION
設定パネルのレイアウトを改善しました。

1. 一般タブの改善:
   - インポート設定のラベル（「インポート設定：」）とラジオボタン（「追記」「上書き」）を横並びに配置し、垂直方向のスペースを節約しました。

2. Aboutタブの改善:
   - Material 3のデザイン方針に合わせ、セクション間の余白（gap）を24pxから12pxに削減しました。
   - 説明文のすぐ上にあった重複するタイトル「Issues-Solo」を削除し、UIをクリーンにしました。

これらの変更は CSS および HTML の調整によって行われており、他のタブのレイアウトには影響を与えないよう配慮しています。

---
*PR created automatically by Jules for task [6525848511339829618](https://jules.google.com/task/6525848511339829618) started by @masanori-satake*