### PR TITLE
履歴と設定のインポート堅牢性向上および未設定ホストへの対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.13.3-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.13.4-blue)](manifest.json)
 [![Coverage](https://img.shields.io/badge/coverage-51%25-orange)](#)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.13.3",
+      "version": "0.13.4",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "JIRA閲覧履歴を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/generate_png_icons.py && python3 scripts/check_version.py && python3 scripts/verify_project_policies.py && python3 scripts/build.py",

--- a/projects/app/_locales/en/messages.json
+++ b/projects/app/_locales/en/messages.json
@@ -212,6 +212,17 @@
   "other": {
     "message": "Other"
   },
+  "unconfiguredHosts": {
+    "message": "Unconfigured Hosts"
+  },
+  "addHostConfirm": {
+    "message": "This host ($1) is not configured. Do you want to add it?",
+    "placeholders": {
+      "1": {
+        "content": "$1"
+      }
+    }
+  },
   "close": {
     "message": "Close"
   },

--- a/projects/app/_locales/ja/messages.json
+++ b/projects/app/_locales/ja/messages.json
@@ -212,6 +212,17 @@
   "other": {
     "message": "その他"
   },
+  "unconfiguredHosts": {
+    "message": "設定未登録ホスト"
+  },
+  "addHostConfirm": {
+    "message": "このホスト ($1) は設定されていません。追加しますか？",
+    "placeholders": {
+      "1": {
+        "content": "$1"
+      }
+    }
+  },
   "close": {
     "message": "閉じる"
   },

--- a/projects/app/db.js
+++ b/projects/app/db.js
@@ -351,16 +351,25 @@ export class IssuesDB {
   async importSettings(jsonText, mode = "add") {
     try {
       const data = JSON.parse(jsonText);
-      let lastId = Date.now();
+      const getNextId = (currentMaxId) => {
+        let nextId = Math.max(Date.now(), currentMaxId + 1);
+        return () => (nextId++).toString();
+      };
 
       if (mode === "overwrite") {
         const toSet = {};
         if (data.settings) {
+          const maxId = data.settings.reduce(
+            (max, s) => Math.max(max, parseInt(s.id, 10) || 0),
+            0,
+          );
+          const generateId = getNextId(maxId);
           const seenIds = new Set();
+
           toSet.settings = data.settings.map((s) => {
             // IDの重複や欠落を修正する
             if (!s.id || seenIds.has(s.id)) {
-              s.id = (lastId++).toString();
+              s.id = generateId();
             }
             seenIds.add(s.id);
             return s;
@@ -382,12 +391,22 @@ export class IssuesDB {
 
         const newSettings = [...currentSettings];
         if (data.settings) {
+          const maxIdInCurrent = currentSettings.reduce(
+            (max, s) => Math.max(max, parseInt(s.id, 10) || 0),
+            0,
+          );
+          const maxIdInImport = data.settings.reduce(
+            (max, s) => Math.max(max, parseInt(s.id, 10) || 0),
+            0,
+          );
+          const generateId = getNextId(Math.max(maxIdInCurrent, maxIdInImport));
           const seenIds = new Set(newSettings.map((s) => s.id));
+
           for (const s of data.settings) {
             if (!newSettings.some((existing) => existing.url === s.url)) {
               // IDの重複を避ける
-              if (seenIds.has(s.id)) {
-                s.id = (lastId++).toString();
+              if (!s.id || seenIds.has(s.id)) {
+                s.id = generateId();
               }
               seenIds.add(s.id);
               newSettings.push(s);

--- a/projects/app/db.js
+++ b/projects/app/db.js
@@ -331,6 +331,10 @@ export class IssuesDB {
         if (!issue.lastAccessed) {
           issue.lastAccessed = Date.now();
         }
+        // 他のブラウザや再インストール時での不整合を防ぐため、開閉状態をリセットする
+        issue.isOpened = false;
+        issue.tabId = null;
+
         store.put(issue);
       }
 
@@ -347,9 +351,21 @@ export class IssuesDB {
   async importSettings(jsonText, mode = "add") {
     try {
       const data = JSON.parse(jsonText);
+      let lastId = Date.now();
+
       if (mode === "overwrite") {
         const toSet = {};
-        if (data.settings) toSet.settings = data.settings;
+        if (data.settings) {
+          const seenIds = new Set();
+          toSet.settings = data.settings.map((s) => {
+            // IDの重複や欠落を修正する
+            if (!s.id || seenIds.has(s.id)) {
+              s.id = (lastId++).toString();
+            }
+            seenIds.add(s.id);
+            return s;
+          });
+        }
         if (data.projectSettings) toSet.projectSettings = data.projectSettings;
         if (data.otherCollapsed !== undefined)
           toSet.otherCollapsed = data.otherCollapsed;
@@ -366,8 +382,14 @@ export class IssuesDB {
 
         const newSettings = [...currentSettings];
         if (data.settings) {
+          const seenIds = new Set(newSettings.map((s) => s.id));
           for (const s of data.settings) {
             if (!newSettings.some((existing) => existing.url === s.url)) {
+              // IDの重複を避ける
+              if (seenIds.has(s.id)) {
+                s.id = (lastId++).toString();
+              }
+              seenIds.add(s.id);
               newSettings.push(s);
             }
           }

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/projects/app/modules/issue-renderer.js
+++ b/projects/app/modules/issue-renderer.js
@@ -2,6 +2,7 @@ import {
   compareIssueKeys,
   getPriorityWeight,
   compareStatus,
+  isUrlMatchHost,
   PRIORITY_MAP,
   STATUS_COLOR_MAP,
   OTHER_COLOR,
@@ -71,7 +72,7 @@ export class IssueRenderer {
     const hostGroups = visibleSettings
       .map((host) => {
         const hostIssues = issues.filter((issue) =>
-          this._isIssueInHost(issue, host.url),
+          isUrlMatchHost(issue.url, host.url),
         );
         return { host, issues: hostIssues };
       })
@@ -91,7 +92,7 @@ export class IssueRenderer {
 
     // 設定されていないホストの課題を抽出
     const unconfiguredIssues = issues.filter((issue) => {
-      return !settings.some((host) => this._isIssueInHost(issue, host.url));
+      return !settings.some((host) => isUrlMatchHost(issue.url, host.url));
     });
 
     if (unconfiguredIssues.length > 0) {
@@ -102,37 +103,6 @@ export class IssueRenderer {
     }
   }
 
-  /**
-   * URLが指定されたホスト設定に合致するか判定します。
-   * @private
-   */
-  _isIssueInHost(issue, hostUrl) {
-    try {
-      const url = new URL(issue.url);
-      const hostUrlLower = hostUrl.toLowerCase();
-      const issueHostname = url.hostname.toLowerCase();
-      const issuePathname = url.pathname.toLowerCase();
-
-      if (hostUrlLower.includes("/")) {
-        const [hostPart, ...pathParts] = hostUrlLower.split("/");
-        const pathPart = "/" + pathParts.join("/");
-        const isCorrectPath =
-          issuePathname === pathPart ||
-          issuePathname.startsWith(pathPart + "/");
-        return (
-          (issueHostname === hostPart ||
-            issueHostname.endsWith("." + hostPart)) &&
-          isCorrectPath
-        );
-      }
-      return (
-        issueHostname === hostUrlLower ||
-        issueHostname.endsWith("." + hostUrlLower)
-      );
-    } catch (e) {
-      return false;
-    }
-  }
 
   /**
    * ホストグループのヘッダーを作成します。
@@ -241,9 +211,9 @@ export class IssueRenderer {
   _createUnconfiguredHeader() {
     const header = document.createElement("div");
     header.className = "project-group-header unconfigured-header";
-    header.style.backgroundColor = "#7A869A22";
-    header.style.color = "#7A869A";
-    header.style.borderLeft = "4px solid #7A869A";
+    header.style.backgroundColor = OTHER_COLOR + "22";
+    header.style.color = OTHER_COLOR;
+    header.style.borderLeft = `4px solid ${OTHER_COLOR}`;
 
     const icon = document.createElement("span");
     icon.className = "material-symbols-outlined";

--- a/projects/app/modules/issue-renderer.js
+++ b/projects/app/modules/issue-renderer.js
@@ -88,6 +88,18 @@ export class IssueRenderer {
         this._renderProjectGroups(hostIssues, projectSettings, otherCollapsed);
       }
     });
+
+    // 設定されていないホストの課題を抽出
+    const unconfiguredIssues = issues.filter((issue) => {
+      return !settings.some((host) => this._isIssueInHost(issue, host.url));
+    });
+
+    if (unconfiguredIssues.length > 0) {
+      this.listElement.appendChild(this._createUnconfiguredHeader());
+      unconfiguredIssues.forEach((issue) => {
+        this.listElement.appendChild(this._createIssueItem(issue, true));
+      });
+    }
   }
 
   /**
@@ -223,6 +235,30 @@ export class IssueRenderer {
   }
 
   /**
+   * "設定未登録ホスト"グループのヘッダーを作成します。
+   * @private
+   */
+  _createUnconfiguredHeader() {
+    const header = document.createElement("div");
+    header.className = "project-group-header unconfigured-header";
+    header.style.backgroundColor = "#7A869A22";
+    header.style.color = "#7A869A";
+    header.style.borderLeft = "4px solid #7A869A";
+
+    const icon = document.createElement("span");
+    icon.className = "material-symbols-outlined";
+    icon.textContent = "error_outline";
+    header.appendChild(icon);
+
+    const name = document.createElement("span");
+    name.textContent =
+      chrome.i18n.getMessage("unconfiguredHosts") || "Unconfigured Hosts";
+    header.appendChild(name);
+
+    return header;
+  }
+
+  /**
    * "その他"グループのヘッダーを作成します。
    * @private
    */
@@ -256,9 +292,9 @@ export class IssueRenderer {
    * 課題1件分のアイテム要素を作成します。
    * @private
    */
-  _createIssueItem(issue) {
+  _createIssueItem(issue, isDisabled = false) {
     const item = document.createElement("div");
-    item.className = "issue-item";
+    item.className = `issue-item ${isDisabled ? "disabled" : ""}`;
     item.title = issue.title;
 
     const indicators = document.createElement("div");

--- a/projects/app/modules/issue-renderer.js
+++ b/projects/app/modules/issue-renderer.js
@@ -103,7 +103,6 @@ export class IssueRenderer {
     }
   }
 
-
   /**
    * ホストグループのヘッダーを作成します。
    * @private

--- a/projects/app/modules/issue-renderer.js
+++ b/projects/app/modules/issue-renderer.js
@@ -103,6 +103,7 @@ export class IssueRenderer {
     }
   }
 
+
   /**
    * ホストグループのヘッダーを作成します。
    * @private

--- a/projects/app/modules/settings-manager.js
+++ b/projects/app/modules/settings-manager.js
@@ -434,7 +434,7 @@ export class SettingsManager {
     const nameInput = document.getElementById("host-name");
     const urlInput = document.getElementById("host-url");
 
-    if (host) {
+    if (host && host.id) {
       dialog.dataset.editId = host.id;
       titleEl.textContent = chrome.i18n.getMessage("editHostTitle");
       titleEl.dataset.i18n = "editHostTitle";
@@ -442,6 +442,15 @@ export class SettingsManager {
       confirmBtn.dataset.i18n = "update";
       nameInput.value = host.name;
       urlInput.value = host.url;
+    } else if (host) {
+      // IDがない場合は新規追加だが初期値あり
+      delete dialog.dataset.editId;
+      titleEl.textContent = chrome.i18n.getMessage("addHostTitle");
+      titleEl.dataset.i18n = "addHostTitle";
+      confirmBtn.textContent = chrome.i18n.getMessage("add");
+      confirmBtn.dataset.i18n = "add";
+      nameInput.value = host.name || "";
+      urlInput.value = host.url || "";
     } else {
       delete dialog.dataset.editId;
       titleEl.textContent = chrome.i18n.getMessage("addHostTitle");

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -140,6 +140,11 @@ header {
   background-color: var(--hover-bg);
 }
 
+.issue-item.disabled {
+  opacity: 0.5;
+  filter: grayscale(1);
+}
+
 .status-indicators {
   display: flex;
   flex-direction: column;

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -344,7 +344,9 @@ class SidePanel {
           () => {
             this.settings.open();
             // 一般タブ（ホスト設定）を表示
-            const generalBtn = document.querySelector('.tab-btn[data-tab="general"]');
+            const generalBtn = document.querySelector(
+              '.tab-btn[data-tab="general"]',
+            );
             if (generalBtn) generalBtn.click();
             this.settings.openHostDialog({ name: "", url: host });
           },

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -327,6 +327,33 @@ class SidePanel {
    * @param {Object} issue 課題オブジェクト
    */
   async handleIssueClick(issue) {
+    // ホスト設定がない場合は追加を促す
+    const settings = await this.db.getSettings();
+    const isConfigured = settings.some((host) =>
+      this.renderer._isIssueInHost(issue, host.url),
+    );
+
+    if (!isConfigured) {
+      try {
+        const url = new URL(issue.url);
+        const host = url.hostname;
+        this.settings.showConfirm(
+          chrome.i18n.getMessage("confirm"),
+          chrome.i18n.getMessage("addHostConfirm", [host]),
+          () => {
+            this.settings.open();
+            // 一般タブ（ホスト設定）を表示
+            const generalBtn = document.querySelector('.tab-btn[data-tab="general"]');
+            if (generalBtn) generalBtn.click();
+            this.settings.openHostDialog({ name: "", url: host });
+          },
+        );
+      } catch (e) {
+        console.error("Invalid issue URL", e);
+      }
+      return;
+    }
+
     if (issue.isOpened && issue.tabId) {
       try {
         await chrome.tabs.update(issue.tabId, { active: true });

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -1,6 +1,7 @@
 import { IssuesDB } from "./db.js";
 import { IssueRenderer } from "./modules/issue-renderer.js";
 import { SettingsManager } from "./modules/settings-manager.js";
+import { isUrlMatchHost } from "./utils.js";
 
 /**
  * SidePanel クラスは、拡張機能のサイドパネル全体のライフサイクルと
@@ -330,7 +331,7 @@ class SidePanel {
     // ホスト設定がない場合は追加を促す
     const settings = await this.db.getSettings();
     const isConfigured = settings.some((host) =>
-      this.renderer._isIssueInHost(issue, host.url),
+      isUrlMatchHost(issue.url, host.url),
     );
 
     if (!isConfigured) {
@@ -343,9 +344,7 @@ class SidePanel {
           () => {
             this.settings.open();
             // 一般タブ（ホスト設定）を表示
-            const generalBtn = document.querySelector(
-              '.tab-btn[data-tab="general"]',
-            );
+            const generalBtn = document.querySelector('.tab-btn[data-tab="general"]');
             if (generalBtn) generalBtn.click();
             this.settings.openHostDialog({ name: "", url: host });
           },

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -344,9 +344,7 @@ class SidePanel {
           () => {
             this.settings.open();
             // 一般タブ（ホスト設定）を表示
-            const generalBtn = document.querySelector(
-              '.tab-btn[data-tab="general"]',
-            );
+            const generalBtn = document.querySelector('.tab-btn[data-tab="general"]');
             if (generalBtn) generalBtn.click();
             this.settings.openHostDialog({ name: "", url: host });
           },

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -343,7 +343,9 @@ class SidePanel {
           () => {
             this.settings.open();
             // 一般タブ（ホスト設定）を表示
-            const generalBtn = document.querySelector('.tab-btn[data-tab="general"]');
+            const generalBtn = document.querySelector(
+              '.tab-btn[data-tab="general"]',
+            );
             if (generalBtn) generalBtn.click();
             this.settings.openHostDialog({ name: "", url: host });
           },

--- a/projects/app/utils.js
+++ b/projects/app/utils.js
@@ -157,6 +157,39 @@ export function getStatusWeight(status) {
 }
 
 /**
+ * URLが指定されたホスト設定に合致するか判定します。
+ *
+ * @param {string} urlString 判定対象のURL文字列
+ * @param {string} hostUrl 登録されているホスト設定のURL
+ * @returns {boolean}
+ */
+export function isUrlMatchHost(urlString, hostUrl) {
+  try {
+    const url = new URL(urlString);
+    const hostUrlLower = hostUrl.toLowerCase();
+    const issueHostname = url.hostname.toLowerCase();
+    const issuePathname = url.pathname.toLowerCase();
+
+    if (hostUrlLower.includes("/")) {
+      const [hostPart, ...pathParts] = hostUrlLower.split("/");
+      const pathPart = "/" + pathParts.join("/");
+      const isCorrectPath =
+        issuePathname === pathPart || issuePathname.startsWith(pathPart + "/");
+      return (
+        (issueHostname === hostPart ||
+          issueHostname.endsWith("." + hostPart)) &&
+        isCorrectPath
+      );
+    }
+    return (
+      issueHostname === hostUrlLower || issueHostname.endsWith("." + hostUrlLower)
+    );
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
  * ステータスの比較
  */
 export function compareStatus(a, b, direction) {

--- a/projects/app/utils.js
+++ b/projects/app/utils.js
@@ -182,8 +182,7 @@ export function isUrlMatchHost(urlString, hostUrl) {
       );
     }
     return (
-      issueHostname === hostUrlLower ||
-      issueHostname.endsWith("." + hostUrlLower)
+      issueHostname === hostUrlLower || issueHostname.endsWith("." + hostUrlLower)
     );
   } catch (e) {
     return false;

--- a/projects/app/utils.js
+++ b/projects/app/utils.js
@@ -182,7 +182,8 @@ export function isUrlMatchHost(urlString, hostUrl) {
       );
     }
     return (
-      issueHostname === hostUrlLower || issueHostname.endsWith("." + hostUrlLower)
+      issueHostname === hostUrlLower ||
+      issueHostname.endsWith("." + hostUrlLower)
     );
   } catch (e) {
     return false;

--- a/tests/e2e/import-flow.spec.js
+++ b/tests/e2e/import-flow.spec.js
@@ -19,10 +19,7 @@ test.describe("Import and Interaction Flow", () => {
     return testInfo.annotations.find((a) => a.type === "sidePanel").description;
   }
 
-  test("should handle unconfigured host from imported history", async ({
-    context,
-    extensionId,
-  }, testInfo) => {
+  test("should handle unconfigured host from imported history", async ({ context, extensionId }, testInfo) => {
     const sidePanel = await getSidePanel(testInfo);
 
     // 1. 設定を空にする（初期設定の Atlassian.net も消す）
@@ -37,23 +34,23 @@ test.describe("Import and Interaction Flow", () => {
       title: "Imported Issue",
       lastAccessed: Date.now(),
       isOpened: true, // これはインポート時に false になるはず
-      tabId: 12345,
+      tabId: 12345
     });
 
     // クリップボードをモックしてインポートボタンをクリック
     await sidePanel.evaluate((text) => {
-      Object.defineProperty(navigator, "clipboard", {
+      Object.defineProperty(navigator, 'clipboard', {
         value: {
           readText: async () => text,
-          writeText: async () => {},
-        },
+          writeText: async () => {}
+        }
       });
     }, ndjson);
 
     await sidePanel.click("#settings-btn");
 
     // Playwright handle alert/confirm
-    sidePanel.on("dialog", (dialog) => dialog.accept());
+    sidePanel.on('dialog', dialog => dialog.accept());
 
     await sidePanel.click("#import-history-btn");
     await sidePanel.click("#close-settings");
@@ -70,17 +67,13 @@ test.describe("Import and Interaction Flow", () => {
     await issueItem.click();
     const confirmDialog = sidePanel.locator("#confirm-dialog");
     await expect(confirmDialog).toBeVisible();
-    await expect(sidePanel.locator("#confirm-message")).toContainText(
-      "imported-host.atlassian.net",
-    );
+    await expect(sidePanel.locator("#confirm-message")).toContainText("imported-host.atlassian.net");
 
     await sidePanel.click("#confirm-ok");
 
     // 設定パネルのホスト追加ダイアログが開いているはず
     await expect(sidePanel.locator("#host-dialog")).toBeVisible();
-    await expect(sidePanel.locator("#host-url")).toHaveValue(
-      "imported-host.atlassian.net",
-    );
+    await expect(sidePanel.locator("#host-url")).toHaveValue("imported-host.atlassian.net");
 
     // 5. ホストを追加して通常表示に戻ることを確認
     await sidePanel.fill("#host-name", "Imported Jira");

--- a/tests/e2e/import-flow.spec.js
+++ b/tests/e2e/import-flow.spec.js
@@ -19,7 +19,10 @@ test.describe("Import and Interaction Flow", () => {
     return testInfo.annotations.find((a) => a.type === "sidePanel").description;
   }
 
-  test("should handle unconfigured host from imported history", async ({ context, extensionId }, testInfo) => {
+  test("should handle unconfigured host from imported history", async ({
+    context,
+    extensionId,
+  }, testInfo) => {
     const sidePanel = await getSidePanel(testInfo);
 
     // 1. 設定を空にする（初期設定の Atlassian.net も消す）
@@ -34,23 +37,23 @@ test.describe("Import and Interaction Flow", () => {
       title: "Imported Issue",
       lastAccessed: Date.now(),
       isOpened: true, // これはインポート時に false になるはず
-      tabId: 12345
+      tabId: 12345,
     });
 
     // クリップボードをモックしてインポートボタンをクリック
     await sidePanel.evaluate((text) => {
-      Object.defineProperty(navigator, 'clipboard', {
+      Object.defineProperty(navigator, "clipboard", {
         value: {
           readText: async () => text,
-          writeText: async () => {}
-        }
+          writeText: async () => {},
+        },
       });
     }, ndjson);
 
     await sidePanel.click("#settings-btn");
 
     // Playwright handle alert/confirm
-    sidePanel.on('dialog', dialog => dialog.accept());
+    sidePanel.on("dialog", (dialog) => dialog.accept());
 
     await sidePanel.click("#import-history-btn");
     await sidePanel.click("#close-settings");
@@ -67,13 +70,17 @@ test.describe("Import and Interaction Flow", () => {
     await issueItem.click();
     const confirmDialog = sidePanel.locator("#confirm-dialog");
     await expect(confirmDialog).toBeVisible();
-    await expect(sidePanel.locator("#confirm-message")).toContainText("imported-host.atlassian.net");
+    await expect(sidePanel.locator("#confirm-message")).toContainText(
+      "imported-host.atlassian.net",
+    );
 
     await sidePanel.click("#confirm-ok");
 
     // 設定パネルのホスト追加ダイアログが開いているはず
     await expect(sidePanel.locator("#host-dialog")).toBeVisible();
-    await expect(sidePanel.locator("#host-url")).toHaveValue("imported-host.atlassian.net");
+    await expect(sidePanel.locator("#host-url")).toHaveValue(
+      "imported-host.atlassian.net",
+    );
 
     // 5. ホストを追加して通常表示に戻ることを確認
     await sidePanel.fill("#host-name", "Imported Jira");

--- a/tests/e2e/import-flow.spec.js
+++ b/tests/e2e/import-flow.spec.js
@@ -1,0 +1,86 @@
+import { test, expect } from "./fixtures";
+
+test.describe("Import and Interaction Flow", () => {
+  test.beforeEach(async ({ context, extensionId }) => {
+    const sidePanel = await context.newPage();
+
+    await sidePanel.addInitScript(() => {
+      window.chrome = window.chrome || {};
+      window.chrome.permissions = window.chrome.permissions || {};
+      window.chrome.permissions.request = async () => true;
+      window.alert = () => {};
+    });
+
+    await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
+    test.info().annotations.push({ type: "sidePanel", description: sidePanel });
+  });
+
+  async function getSidePanel(testInfo) {
+    return testInfo.annotations.find((a) => a.type === "sidePanel").description;
+  }
+
+  test("should handle unconfigured host from imported history", async ({ context, extensionId }, testInfo) => {
+    const sidePanel = await getSidePanel(testInfo);
+
+    // 1. 設定を空にする（初期設定の Atlassian.net も消す）
+    await sidePanel.click("#settings-btn");
+    await sidePanel.click(".host-item .delete-btn");
+    await sidePanel.click("#close-settings");
+
+    // 2. 履歴をインポートする
+    const ndjson = JSON.stringify({
+      url: "https://imported-host.atlassian.net/browse/IMP-1",
+      issueKey: "IMP-1",
+      title: "Imported Issue",
+      lastAccessed: Date.now(),
+      isOpened: true, // これはインポート時に false になるはず
+      tabId: 12345
+    });
+
+    // クリップボードをモックしてインポートボタンをクリック
+    await sidePanel.evaluate((text) => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {
+          readText: async () => text,
+          writeText: async () => {}
+        }
+      });
+    }, ndjson);
+
+    await sidePanel.click("#settings-btn");
+
+    // Playwright handle alert/confirm
+    sidePanel.on('dialog', dialog => dialog.accept());
+
+    await sidePanel.click("#import-history-btn");
+    await sidePanel.click("#close-settings");
+
+    // 3. 未設定ホストとして表示されていることを確認
+    const unconfiguredHeader = sidePanel.locator(".unconfigured-header");
+    await expect(unconfiguredHeader).toBeVisible();
+
+    const issueItem = sidePanel.locator(".issue-item.disabled");
+    await expect(issueItem).toBeVisible();
+    await expect(issueItem.locator(".indicator")).not.toHaveClass(/is-opened/); // Sanitization check
+
+    // 4. クリックしてホスト追加ダイアログが出ることを確認
+    await issueItem.click();
+    const confirmDialog = sidePanel.locator("#confirm-dialog");
+    await expect(confirmDialog).toBeVisible();
+    await expect(sidePanel.locator("#confirm-message")).toContainText("imported-host.atlassian.net");
+
+    await sidePanel.click("#confirm-ok");
+
+    // 設定パネルのホスト追加ダイアログが開いているはず
+    await expect(sidePanel.locator("#host-dialog")).toBeVisible();
+    await expect(sidePanel.locator("#host-url")).toHaveValue("imported-host.atlassian.net");
+
+    // 5. ホストを追加して通常表示に戻ることを確認
+    await sidePanel.fill("#host-name", "Imported Jira");
+    await sidePanel.click("#confirm-host");
+    await sidePanel.click("#close-settings");
+
+    await expect(unconfiguredHeader).not.toBeVisible();
+    await expect(sidePanel.locator(".issue-item:not(.disabled)")).toBeVisible();
+  });
+});

--- a/tests/e2e/settings-drag-drop.spec.js
+++ b/tests/e2e/settings-drag-drop.spec.js
@@ -49,13 +49,19 @@ test.describe("Settings Reordering", () => {
     await sidePanel.evaluate(
       () => (document.querySelector(".tab-content:not(.hidden)").scrollTop = 0),
     );
+    // Use dispatchEvent to trigger drag and drop more reliably in CI
     await secondHost.hover();
+    const secondBox = await secondHost.boundingBox();
+    const firstBox = await firstHost.boundingBox();
+
+    await sidePanel.mouse.move(secondBox.x + secondBox.width / 2, secondBox.y + secondBox.height / 2);
     await sidePanel.mouse.down();
-    // Move to the top half of the first host to trigger 'top' drop position
-    const box = await firstHost.boundingBox();
-    await sidePanel.mouse.move(box.x + box.width / 2, box.y + 10, {
-      steps: 5,
+    await sidePanel.waitForTimeout(200);
+    // Move to the top half of the first host
+    await sidePanel.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + 10, {
+      steps: 20,
     });
+    await sidePanel.waitForTimeout(200);
     await sidePanel.mouse.up();
 
     // Verify order changed
@@ -106,11 +112,16 @@ test.describe("Settings Reordering", () => {
       () => (document.querySelector(".tab-content:not(.hidden)").scrollTop = 0),
     );
     await secondProj.hover();
+    const secondBoxP = await secondProj.boundingBox();
+    const firstBoxP = await firstProj.boundingBox();
+
+    await sidePanel.mouse.move(secondBoxP.x + secondBoxP.width / 2, secondBoxP.y + secondBoxP.height / 2);
     await sidePanel.mouse.down();
-    const box = await firstProj.boundingBox();
-    await sidePanel.mouse.move(box.x + box.width / 2, box.y + 10, {
-      steps: 5,
+    await sidePanel.waitForTimeout(200);
+    await sidePanel.mouse.move(firstBoxP.x + firstBoxP.width / 2, firstBoxP.y + 10, {
+      steps: 20,
     });
+    await sidePanel.waitForTimeout(200);
     await sidePanel.mouse.up();
 
     // Verify order changed

--- a/tests/e2e/settings-drag-drop.spec.js
+++ b/tests/e2e/settings-drag-drop.spec.js
@@ -54,13 +54,20 @@ test.describe("Settings Reordering", () => {
     const secondBox = await secondHost.boundingBox();
     const firstBox = await firstHost.boundingBox();
 
-    await sidePanel.mouse.move(secondBox.x + secondBox.width / 2, secondBox.y + secondBox.height / 2);
+    await sidePanel.mouse.move(
+      secondBox.x + secondBox.width / 2,
+      secondBox.y + secondBox.height / 2,
+    );
     await sidePanel.mouse.down();
     await sidePanel.waitForTimeout(200);
     // Move to the top half of the first host
-    await sidePanel.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + 10, {
-      steps: 20,
-    });
+    await sidePanel.mouse.move(
+      firstBox.x + firstBox.width / 2,
+      firstBox.y + 10,
+      {
+        steps: 20,
+      },
+    );
     await sidePanel.waitForTimeout(200);
     await sidePanel.mouse.up();
 
@@ -115,12 +122,19 @@ test.describe("Settings Reordering", () => {
     const secondBoxP = await secondProj.boundingBox();
     const firstBoxP = await firstProj.boundingBox();
 
-    await sidePanel.mouse.move(secondBoxP.x + secondBoxP.width / 2, secondBoxP.y + secondBoxP.height / 2);
+    await sidePanel.mouse.move(
+      secondBoxP.x + secondBoxP.width / 2,
+      secondBoxP.y + secondBoxP.height / 2,
+    );
     await sidePanel.mouse.down();
     await sidePanel.waitForTimeout(200);
-    await sidePanel.mouse.move(firstBoxP.x + firstBoxP.width / 2, firstBoxP.y + 10, {
-      steps: 20,
-    });
+    await sidePanel.mouse.move(
+      firstBoxP.x + firstBoxP.width / 2,
+      firstBoxP.y + 10,
+      {
+        steps: 20,
+      },
+    );
     await sidePanel.waitForTimeout(200);
     await sidePanel.mouse.up();
 

--- a/tests/unit/db.test.js
+++ b/tests/unit/db.test.js
@@ -195,6 +195,23 @@ describe("IssuesDB", () => {
     expect(count).toBe(3);
   });
 
+  test("importIssues - should sanitize isOpened and tabId", async () => {
+    chrome.storage.local.get.mockImplementation((keys, callback) => {
+      callback({ maxHistoryCount: 50 });
+    });
+    const ndjson = JSON.stringify({
+      url: "url1",
+      issueKey: "K1",
+      isOpened: true,
+      tabId: 999,
+    });
+
+    await db.importIssues(ndjson, "add");
+    const issues = await db.getAllIssues();
+    expect(issues[0].isOpened).toBe(false);
+    expect(issues[0].tabId).toBeNull();
+  });
+
   test("importIssues - overwrite mode", async () => {
     chrome.storage.local.get.mockImplementation((keys, callback) => {
       callback({ maxHistoryCount: 50 });
@@ -249,7 +266,10 @@ describe("IssuesDB", () => {
     chrome.storage.local.get.mockImplementation((keys, callback) => {
       if (keys.includes("projectSettings"))
         callback({ projectSettings: currentProjectSettings });
-      else if (keys.includes("settings")) callback({ settings: [] });
+      else if (keys.includes("settings"))
+        callback({
+          settings: [{ id: "1", name: "Old", url: "old.com", visible: true }],
+        });
       else callback({});
     });
     chrome.storage.local.set.mockImplementation(
@@ -257,7 +277,9 @@ describe("IssuesDB", () => {
     );
 
     const settingsData = {
-      settings: [{ id: "2", name: "New", url: "new.com", visible: true }], // 重複がなければ追加
+      settings: [
+        { id: "1", name: "New", url: "new.com", visible: true }, // IDが重複しているがURLが違うので追加、IDは振り直されるはず
+      ],
       projectSettings: [
         { key: "OLD", color: "#CHANGED" }, // 既存キーは無視（上書きしない）
         { key: "NEW", color: "#000000" }, // 新規キーは追加
@@ -277,6 +299,12 @@ describe("IssuesDB", () => {
       ),
     ).toBe(true);
     expect(updatedProjectSettings.some((p) => p.key === "NEW")).toBe(true);
+
+    const updatedSettings = setCall[0].settings;
+    expect(updatedSettings.length).toBe(2);
+    expect(updatedSettings[0].url).toBe("old.com");
+    expect(updatedSettings[1].url).toBe("new.com");
+    expect(updatedSettings[1].id).not.toBe("1"); // IDが振り直されていること
   });
 
   test("getOtherCollapsed - default and set", async () => {

--- a/tests/unit/issue-renderer.test.js
+++ b/tests/unit/issue-renderer.test.js
@@ -157,8 +157,11 @@ describe("IssueRenderer", () => {
     await renderer.render();
 
     const items = listElement.querySelectorAll(".issue-item");
-    expect(items.length).toBe(1);
+    // K1 は設定に合致し、K2 は未設定ホストとして表示されるため合計2件
+    expect(items.length).toBe(2);
     expect(items[0].querySelector(".issue-key").textContent).toBe("K1");
+    expect(items[1].classList.contains("disabled")).toBe(true);
+    expect(items[1].querySelector(".issue-key").textContent).toBe("K2");
   });
 
   test("should handle collapsed host", async () => {
@@ -234,5 +237,30 @@ describe("IssueRenderer", () => {
     expect(projectHeaders.length).toBe(2); // PROJA グループと other グループ
     expect(projectHeaders[0].textContent).toContain("PROJA");
     expect(projectHeaders[1].textContent).toContain("other");
+  });
+
+  test("should render unconfigured host issues with disabled style", async () => {
+    const issues = [
+      {
+        url: "https://unknown-host.atlassian.net/browse/K1",
+        issueKey: "K1",
+        title: "T1",
+      },
+    ];
+    db.getAllIssues.mockResolvedValue(issues);
+    db.getSettings.mockResolvedValue([
+      { id: "1", name: "Known", url: "known.atlassian.net", visible: true },
+    ]);
+
+    await renderer.render();
+
+    const unconfiguredHeader = listElement.querySelector(
+      ".unconfigured-header",
+    );
+    expect(unconfiguredHeader).toBeTruthy();
+    expect(unconfiguredHeader.textContent).toContain("unconfiguredHosts");
+
+    const item = listElement.querySelector(".issue-item");
+    expect(item.classList.contains("disabled")).toBe(true);
   });
 });

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -5,6 +5,7 @@ import {
   compareIssueKeys,
   getPriorityWeight,
   compareStatus,
+  isUrlMatchHost,
 } from "../../projects/app/utils.js";
 
 /**
@@ -76,5 +77,16 @@ describe("utils.js", () => {
       storedUrl: "myjira.atlassian.net",
       permissionOrigin: "https://myjira.atlassian.net/*",
     });
+  });
+
+  test("isUrlMatchHost", () => {
+    const issueUrl = "https://test.atlassian.net/browse/PROJ-1";
+
+    expect(isUrlMatchHost(issueUrl, "test.atlassian.net")).toBe(true);
+    expect(isUrlMatchHost(issueUrl, "other.atlassian.net")).toBe(false);
+
+    const issueUrlWithPath = "https://myjira.com/jira/browse/PROJ-1";
+    expect(isUrlMatchHost(issueUrlWithPath, "myjira.com/jira")).toBe(true);
+    expect(isUrlMatchHost(issueUrlWithPath, "myjira.com/other")).toBe(false);
   });
 });


### PR DESCRIPTION
このプルリクエストでは、履歴データと設定データのインポート時の堅牢性を向上させ、未設定のJiraホストに対するユーザー体験を改善しました。

主な変更点：
1. **履歴データのサニタイズ**: インポート時に `isOpened` を `false`、`tabId` を `null` にリセットすることで、異なるブラウザや再インストール時におけるタブ状態の不整合を防ぎます。
2. **未設定ホストの可視化**: 設定に含まれていないJiraホストの履歴を、サイドパネル上で「設定未登録ホスト」としてグループ化し、グレーアウト表示するようにしました。
3. **ホスト追加フローの統合**: 未設定ホストの課題をクリックすると、ホストの追加を確認するダイアログを表示し、承諾した場合はホストURLが自動入力された状態で設定パネルが開くようにしました。これにより、スムーズな初期セットアップが可能です。
4. **設定IDの互換性確保**: 設定データのインポート時に `id` プロパティの重複や欠落を検知し、自動的にユニークなIDを振り直すようにしました。
5. **テストの拡充**: 
   - `IssuesDB` のインポート・サニタイズロジックに対するユニットテストを追加。
   - `IssueRenderer` の未設定ホスト表示ロジックに対するユニットテストを追加。
   - インポートからホスト追加までの一連のフローを検証する Playwright E2E テストを追加。

また、これらの変更に伴い、バージョンを `0.13.4` に更新しました。

---
*PR created automatically by Jules for task [107904707164955241](https://jules.google.com/task/107904707164955241) started by @masanori-satake*