### PR TITLE
重複タブ起動防止機能の実装

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -16,7 +16,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.21
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: SECURITY\.md
@@ -25,14 +25,14 @@ repos:
           - mdformat-tables
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.2
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         types_or: [javascript, css, html]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,6 @@ repos:
         exclude: SECURITY\.md
         additional_dependencies:
           - mdformat-gfm
-          - mdformat-tables
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.13.7-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.13.8-blue)](manifest.json)
 [![Coverage](https://img.shields.io/badge/coverage-51%25-orange)](#)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.13.8-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.13.9-blue)](manifest.json)
 [![Coverage](https://img.shields.io/badge/coverage-51%25-orange)](#)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.13.7",
+      "version": "0.13.8",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.13.8",
+      "version": "0.13.9",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "JIRA閲覧履歴を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/generate_png_icons.py && python3 scripts/check_version.py && python3 scripts/verify_project_policies.py && python3 scripts/build.py",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "description": "JIRA閲覧履歴を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "build": "python3 scripts/generate_png_icons.py && python3 scripts/check_version.py && python3 scripts/verify_project_policies.py && python3 scripts/build.py",

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/projects/app/modules/issue-renderer.js
+++ b/projects/app/modules/issue-renderer.js
@@ -100,6 +100,7 @@ export class IssueRenderer {
     if (unconfiguredIssues.length > 0) {
       this.listElement.appendChild(this._createUnconfiguredHeader());
       unconfiguredIssues.forEach((issue) => {
+        // 設定未登録ホストの課題は常に disabled 状態（不透明度0.5、グレースケール）にする。
         const isLoading = this.loadingUrls.has(issue.url);
         this.listElement.appendChild(
           this._createIssueItem(issue, true, isLoading),
@@ -159,6 +160,7 @@ export class IssueRenderer {
         );
         if (!proj.isCollapsed) {
           projIssues.forEach((issue) => {
+            // クリック後、読み込み中（loading-state）は disabled スタイルも同時に適用する。
             const isLoading = this.loadingUrls.has(issue.url);
             this.listElement.appendChild(
               this._createIssueItem(issue, isLoading, isLoading),
@@ -172,6 +174,7 @@ export class IssueRenderer {
       this.listElement.appendChild(this._createOtherHeader(otherCollapsed));
       if (!otherCollapsed) {
         remainingIssues.forEach((issue) => {
+          // その他グループの課題も、読み込み中は disabled スタイルと loading-state を適用。
           const isLoading = this.loadingUrls.has(issue.url);
           this.listElement.appendChild(
             this._createIssueItem(issue, isLoading, isLoading),
@@ -271,9 +274,13 @@ export class IssueRenderer {
   /**
    * 課題1件分のアイテム要素を作成します。
    * @private
+   * @param {Object} issue 課題オブジェクト
+   * @param {boolean} isDisabled 無効化（見た目のみ）の状態か
+   * @param {boolean} isLoading 読み込み中（操作不可）の状態か
    */
   _createIssueItem(issue, isDisabled = false, isLoading = false) {
     const item = document.createElement("div");
+    // loading-state は pointer-events: none を含み、物理的な操作を無効化する。
     item.className = `issue-item ${isDisabled ? "disabled" : ""} ${
       isLoading ? "loading-state" : ""
     }`;

--- a/projects/app/modules/issue-renderer.js
+++ b/projects/app/modules/issue-renderer.js
@@ -16,11 +16,13 @@ export class IssueRenderer {
    * @param {HTMLElement} listElement リストを表示するコンテナ要素
    * @param {Object} db IssuesDB インスタンス
    * @param {Function} onIssueClick 課題クリック時のコールバック
+   * @param {Set<string>} loadingUrls 読み込み中の課題URLのセット
    */
-  constructor(listElement, db, onIssueClick) {
+  constructor(listElement, db, onIssueClick, loadingUrls = new Set()) {
     this.listElement = listElement;
     this.db = db;
     this.onIssueClick = onIssueClick;
+    this.loadingUrls = loadingUrls;
   }
 
   /**
@@ -98,7 +100,10 @@ export class IssueRenderer {
     if (unconfiguredIssues.length > 0) {
       this.listElement.appendChild(this._createUnconfiguredHeader());
       unconfiguredIssues.forEach((issue) => {
-        this.listElement.appendChild(this._createIssueItem(issue, true));
+        const isLoading = this.loadingUrls.has(issue.url);
+        this.listElement.appendChild(
+          this._createIssueItem(issue, true, isLoading),
+        );
       });
     }
   }
@@ -154,7 +159,10 @@ export class IssueRenderer {
         );
         if (!proj.isCollapsed) {
           projIssues.forEach((issue) => {
-            this.listElement.appendChild(this._createIssueItem(issue));
+            const isLoading = this.loadingUrls.has(issue.url);
+            this.listElement.appendChild(
+              this._createIssueItem(issue, isLoading, isLoading),
+            );
           });
         }
       }
@@ -164,7 +172,10 @@ export class IssueRenderer {
       this.listElement.appendChild(this._createOtherHeader(otherCollapsed));
       if (!otherCollapsed) {
         remainingIssues.forEach((issue) => {
-          this.listElement.appendChild(this._createIssueItem(issue));
+          const isLoading = this.loadingUrls.has(issue.url);
+          this.listElement.appendChild(
+            this._createIssueItem(issue, isLoading, isLoading),
+          );
         });
       }
     }
@@ -261,9 +272,11 @@ export class IssueRenderer {
    * 課題1件分のアイテム要素を作成します。
    * @private
    */
-  _createIssueItem(issue, isDisabled = false) {
+  _createIssueItem(issue, isDisabled = false, isLoading = false) {
     const item = document.createElement("div");
-    item.className = `issue-item ${isDisabled ? "disabled" : ""}`;
+    item.className = `issue-item ${isDisabled ? "disabled" : ""} ${
+      isLoading ? "loading-state" : ""
+    }`;
     item.title = issue.title;
 
     const indicators = document.createElement("div");

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -145,6 +145,12 @@ header {
   filter: grayscale(1);
 }
 
+.issue-item.loading-state {
+  opacity: 0.5;
+  filter: grayscale(1);
+  pointer-events: none;
+}
+
 .status-indicators {
   display: flex;
   flex-direction: column;

--- a/projects/app/sidepanel.css
+++ b/projects/app/sidepanel.css
@@ -33,8 +33,9 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   margin: 0;
   padding: 0;
   background-color: var(--bg-color);

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -300,18 +300,9 @@ class SidePanel {
     });
 
     // メッセージ受信
-    chrome.runtime.onMessage.addListener(async (message) => {
+    chrome.runtime.onMessage.addListener((message) => {
       if (message.type === "DB_UPDATED") {
-        if (this.loadingUrls.size > 0) {
-          const issues = await this.db.getAllIssues();
-          for (const url of this.loadingUrls) {
-            const issue = issues.find((i) => i.url === url);
-            if (issue && issue.isOpened) {
-              this.loadingUrls.delete(url);
-            }
-          }
-        }
-        this.renderer.render();
+        this.handleDbUpdated();
       }
     });
 
@@ -340,6 +331,7 @@ class SidePanel {
    * @param {Object} issue 課題オブジェクト
    */
   async handleIssueClick(issue) {
+    // すでに読み込み中の場合は、重複して開かないようにガードする
     if (this.loadingUrls.has(issue.url)) {
       return;
     }
@@ -374,20 +366,47 @@ class SidePanel {
     }
 
     if (issue.isOpened && issue.tabId) {
+      // すでに開いているタブがある場合は、そのタブをアクティブにする
       try {
         await chrome.tabs.update(issue.tabId, { active: true });
         const tab = await chrome.tabs.get(issue.tabId);
         await chrome.windows.update(tab.windowId, { focused: true });
       } catch (e) {
+        // タブが閉じられているなどの理由で失敗した場合は、新規タブで開く
         this._startLoading(issue.url);
         chrome.tabs.create({ url: issue.url });
       }
     } else {
+      // 開いていない場合は、新規タブで開く。同時に読み込み中状態にする。
       this._startLoading(issue.url);
       chrome.tabs.create({ url: issue.url });
     }
 
+    // 最終アクセス時刻の更新。
+    // _startLoading 内でも renderer.render() を呼んでいるが、
+    // ここで upsertIssue を行うとDB_UPDATEDメッセージが飛び、
+    // handleDbUpdated を通じて最新の opened 状態を含めた再描画が行われる。
     await this._updateLastAccessed(issue);
+  }
+
+  /**
+   * データベース更新メッセージ受信時の処理を行います。
+   * 読み込み中状態のURLが「開いている」状態に変わったかを確認し、必要に応じて解除します。
+   * @private
+   */
+  async handleDbUpdated() {
+    if (this.loadingUrls.size > 0) {
+      const issues = await this.db.getAllIssues();
+      for (const url of this.loadingUrls) {
+        const issue = issues.find((i) => i.url === url);
+        // タブが開かれ、content.js から background.js 経由で DB が更新されると
+        // isOpened が true になるため、それを検知して読み込み中を解除する。
+        if (issue && issue.isOpened) {
+          this.loadingUrls.delete(url);
+        }
+      }
+    }
+    await this.renderer.render();
   }
 
   /**
@@ -398,7 +417,10 @@ class SidePanel {
    */
   _startLoading(url) {
     this.loadingUrls.add(url);
+    // 即座に見た目を反映させる
     this.renderer.render();
+
+    // ネットワークエラーや読み込み失敗に備え、一定時間で強制解除する。
     setTimeout(() => {
       if (this.loadingUrls.has(url)) {
         this.loadingUrls.delete(url);
@@ -414,8 +436,9 @@ class SidePanel {
   async _updateLastAccessed(issue) {
     const sortSettings = await this.db.getSortSettings();
     if (sortSettings.type === "lastAccessed") {
+      // upsertIssue は background.js で DB_UPDATED メッセージを送信する。
       await this.db.upsertIssue({ ...issue, lastAccessed: Date.now() });
-      await this.renderer.render();
+      // render() は handleDbUpdated で呼ばれるためここでは明示的に呼ばない
     }
   }
 

--- a/projects/app/sidepanel.js
+++ b/projects/app/sidepanel.js
@@ -10,10 +10,12 @@ import { isUrlMatchHost } from "./utils.js";
 class SidePanel {
   constructor() {
     this.db = new IssuesDB();
+    this.loadingUrls = new Set();
     this.renderer = new IssueRenderer(
       document.getElementById("issue-list"),
       this.db,
       this.handleIssueClick.bind(this),
+      this.loadingUrls,
     );
     this.settings = new SettingsManager(this.db, this.renderer);
 
@@ -298,8 +300,19 @@ class SidePanel {
     });
 
     // メッセージ受信
-    chrome.runtime.onMessage.addListener((message) => {
-      if (message.type === "DB_UPDATED") this.renderer.render();
+    chrome.runtime.onMessage.addListener(async (message) => {
+      if (message.type === "DB_UPDATED") {
+        if (this.loadingUrls.size > 0) {
+          const issues = await this.db.getAllIssues();
+          for (const url of this.loadingUrls) {
+            const issue = issues.find((i) => i.url === url);
+            if (issue && issue.isOpened) {
+              this.loadingUrls.delete(url);
+            }
+          }
+        }
+        this.renderer.render();
+      }
     });
 
     // ストレージ変更監視
@@ -327,6 +340,10 @@ class SidePanel {
    * @param {Object} issue 課題オブジェクト
    */
   async handleIssueClick(issue) {
+    if (this.loadingUrls.has(issue.url)) {
+      return;
+    }
+
     // ホスト設定がない場合は追加を促す
     const settings = await this.db.getSettings();
     const isConfigured = settings.some((host) =>
@@ -362,12 +379,39 @@ class SidePanel {
         const tab = await chrome.tabs.get(issue.tabId);
         await chrome.windows.update(tab.windowId, { focused: true });
       } catch (e) {
+        this._startLoading(issue.url);
         chrome.tabs.create({ url: issue.url });
       }
     } else {
+      this._startLoading(issue.url);
       chrome.tabs.create({ url: issue.url });
     }
 
+    await this._updateLastAccessed(issue);
+  }
+
+  /**
+   * 指定したURLの読み込み状態を開始します。
+   * 5秒後に自動的に解除されます。
+   * @private
+   * @param {string} url
+   */
+  _startLoading(url) {
+    this.loadingUrls.add(url);
+    this.renderer.render();
+    setTimeout(() => {
+      if (this.loadingUrls.has(url)) {
+        this.loadingUrls.delete(url);
+        this.renderer.render();
+      }
+    }, 5000);
+  }
+
+  /**
+   * 課題クリック時の動作（共通）。
+   * @private
+   */
+  async _updateLastAccessed(issue) {
     const sortSettings = await this.db.getSortSettings();
     if (sortSettings.type === "lastAccessed") {
       await this.db.upsertIssue({ ...issue, lastAccessed: Date.now() });

--- a/tests/unit/issue-renderer.test.js
+++ b/tests/unit/issue-renderer.test.js
@@ -263,4 +263,25 @@ describe("IssueRenderer", () => {
     const item = listElement.querySelector(".issue-item");
     expect(item.classList.contains("disabled")).toBe(true);
   });
+
+  test("should render items in loadingUrls with loading-state class", async () => {
+    const issues = [
+      {
+        url: "https://h1.atlassian.net/browse/K1",
+        issueKey: "K1",
+        title: "T1",
+      },
+    ];
+    db.getAllIssues.mockResolvedValue(issues);
+    db.getSettings.mockResolvedValue([
+      { id: "1", name: "H1", url: "h1.atlassian.net", visible: true },
+    ]);
+
+    const loadingUrls = new Set(["https://h1.atlassian.net/browse/K1"]);
+    renderer = new IssueRenderer(listElement, db, onIssueClick, loadingUrls);
+    await renderer.render();
+
+    const item = listElement.querySelector(".issue-item");
+    expect(item.classList.contains("loading-state")).toBe(true);
+  });
 });


### PR DESCRIPTION
Issues-Soloのサイドパネルで、履歴項目をクリックした際にタブが開くまでの間（最大5秒、または読み込み完了まで）、該当する履歴項目を操作不可にし、見た目でも分かるように（不透明度0.5＋グレースケール）修正しました。これにより、せっかちな連打や誤クリックによる同じIssueの重複タブ起動を防止します。

---
*PR created automatically by Jules for task [37729487703813322](https://jules.google.com/task/37729487703813322) started by @masanori-satake*