### PR TITLE
Remove version number from extension name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issues-Solo
 
-[![version](https://img.shields.io/badge/version-0.13.10-blue)](manifest.json)
+[![version](https://img.shields.io/badge/version-0.13.11-blue)](manifest.json)
 [![Coverage](https://img.shields.io/badge/coverage-51%25-orange)](#)
 [![Privacy-Local Only](https://img.shields.io/badge/Privacy-Local%20Only-brightgreen)](AGENTS.md)
 [![Manifest V3](https://img.shields.io/badge/Manifest-V3-orange)](manifest.json)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issues-solo",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issues-solo",
-      "version": "0.13.10",
+      "version": "0.13.11",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issues-solo",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "description": "JIRA閲覧履歴を管理するローカル完結型Chrome拡張機能",
   "scripts": {
     "version:sync": "python3 scripts/sync_version.py",

--- a/projects/app/_locales/en/messages.json
+++ b/projects/app/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "extName": {
-    "message": "Issues-Solo v0.13.10"
+    "message": "Issues-Solo"
   },
   "extDescription": {
     "message": "Local-only Chrome extension to manage JIRA browsing history."

--- a/projects/app/_locales/ja/messages.json
+++ b/projects/app/_locales/ja/messages.json
@@ -1,6 +1,6 @@
 {
    "extName": {
-     "message": "Issues-Solo v0.13.10"
+     "message": "Issues-Solo"
    },
   "extDescription": {
     "message": "JIRA閲覧履歴を管理するローカル完結型Chrome拡張機能"

--- a/projects/app/manifest.json
+++ b/projects/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "permissions": [

--- a/projects/app/metadata.json
+++ b/projects/app/metadata.json
@@ -1,3 +1,0 @@
-{
-  "extName": "Issues-Solo v0.13.10"
-}

--- a/scripts/check_root_files.py
+++ b/scripts/check_root_files.py
@@ -87,7 +87,6 @@ def check_project_cleanliness():
         "utils.js",
         "LICENSE",
         "MaterialSymbolsOutlined.woff2",
-        "metadata.json",
     }
     app_allowed_dirs = {"_locales", "assets", "modules"}
     app_success = check_directory_cleanliness(

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import re
+import os
 
 
 def check_version_consistency():

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -24,33 +24,6 @@ def check_version_consistency():
                 package_lock.get("packages", {}).get("", {}).get("version")
             )
 
-        # metadata.json (SSoT for extension name)
-        metadata_version = None
-        metadata_path = "projects/app/metadata.json"
-        if os.path.exists(metadata_path):
-            with open(metadata_path, "r", encoding="utf-8") as f:
-                metadata = json.load(f)
-                ext_name = metadata.get("extName", "")
-                match = re.search(r"v([\d\.]+)", ext_name)
-                metadata_version = match.group(1) if match else None
-
-        # messages.json (extName in all locales)
-        locales_dir = "projects/app/_locales"
-        messages_versions = {}
-        for lang in os.listdir(locales_dir):
-            msg_path = os.path.join(locales_dir, lang, "messages.json")
-            if os.path.exists(msg_path):
-                with open(msg_path, "r", encoding="utf-8") as f:
-                    messages = json.load(f)
-                    ext_name_msg = messages.get("extName", {}).get("message")
-                    if ext_name_msg:
-                        match = re.search(r"v([\d\.]+)", ext_name_msg)
-                        messages_versions[f"messages.json ({lang})"] = (
-                            match.group(1) if match else None
-                        )
-                    else:
-                        messages_versions[f"messages.json ({lang})"] = None
-
         # README.md (Badge)
         readme_version = None
         with open("README.md", "r") as f:
@@ -68,9 +41,7 @@ def check_version_consistency():
             "package-lock.json (root)": package_lock_version,
             'package-lock.json (packages[""])': package_lock_root_version,
             "README.md (badge)": readme_version,
-            "metadata.json": metadata_version,
         }
-        versions.update(messages_versions)
 
         mismatch = False
 

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -1,7 +1,6 @@
 import json
 import sys
 import re
-import os
 
 
 def check_version_consistency():

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -1,6 +1,5 @@
 import json
 import re
-import os
 import sys
 
 

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -17,17 +17,7 @@ def sync_version():
 
         print(f"Syncing version {version}...")
 
-        # 2. Update metadata.json (Single Source of Truth for extension name)
-        metadata_path = "projects/app/metadata.json"
-        new_ext_name = f"Issues-Solo v{version}"
-        metadata = {"extName": new_ext_name}
-
-        with open(metadata_path, "w", encoding="utf-8") as f:
-            json.dump(metadata, f, indent=2, ensure_ascii=False)
-            f.write("\n")
-        print(f"  Updated {metadata_path}")
-
-        # 3. Update manifest.json
+        # 2. Update manifest.json
         manifest_path = "projects/app/manifest.json"
         with open(manifest_path, "r", encoding="utf-8") as f:
             manifest = json.load(f)
@@ -39,24 +29,7 @@ def sync_version():
                 f.write("\n")
             print(f"  Updated {manifest_path}")
 
-        # 4. Update extName in all messages.json files from metadata.json
-        locales_dir = "projects/app/_locales"
-        for lang in os.listdir(locales_dir):
-            msg_path = os.path.join(locales_dir, lang, "messages.json")
-            if os.path.exists(msg_path):
-                with open(msg_path, "r", encoding="utf-8") as f:
-                    messages = json.load(f)
-
-                if messages.get("extName", {}).get("message") != new_ext_name:
-                    if "extName" not in messages:
-                        messages["extName"] = {}
-                    messages["extName"]["message"] = new_ext_name
-                    with open(msg_path, "w", encoding="utf-8") as f:
-                        json.dump(messages, f, indent=2, ensure_ascii=False)
-                        f.write("\n")
-                    print(f"  Updated {msg_path}")
-
-        # 5. Update README.md badge
+        # 3. Update README.md badge
         readme_path = "README.md"
         with open(readme_path, "r", encoding="utf-8") as f:
             readme_content = f.read()

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -1,5 +1,6 @@
 import json
 import re
+import os
 import sys
 
 

--- a/tests/e2e/basic.spec.js
+++ b/tests/e2e/basic.spec.js
@@ -3,7 +3,5 @@ import { test, expect } from "./fixtures";
 test("should load the extension sidepanel", async ({ page, extensionId }) => {
   await page.goto(`chrome-extension://${extensionId}/sidepanel.html`);
   const title = await page.textContent("title");
-  // manifest.json のバージョンを取得
-  const manifest = require("../../projects/app/manifest.json");
-  expect(title).toBe(`Issues-Solo v${manifest.version}`);
+  expect(title).toBe("Issues-Solo");
 });


### PR DESCRIPTION
I have removed the version number suffix (e.g., " v0.13.10") from the extension name "Issues-Solo" in both English and Japanese localization files. 

Key changes include:
1. **Localization**: Updated `_locales/*/messages.json` to set `extName` to simply "Issues-Solo".
2. **Refactoring**: Removed `projects/app/metadata.json`, which was previously used as a reference for the versioned name.
3. **Scripts**: 
   - `scripts/sync_version.py` no longer injects the version into message files.
   - `scripts/check_version.py` no longer validates version suffixes in the extension name.
   - `scripts/check_root_files.py` was updated to reflect the removal of `metadata.json`.
4. **Tests**: Updated the basic E2E test to expect the new unversioned title.

The version remains accessible via `chrome.runtime.getManifest().version` and is still displayed in the "About" tab of the settings panel.

---
*PR created automatically by Jules for task [14678315132018192077](https://jules.google.com/task/14678315132018192077) started by @masanori-satake*